### PR TITLE
Fix ruff config

### DIFF
--- a/.github/workflows/check_api_docstrings.yml
+++ b/.github/workflows/check_api_docstrings.yml
@@ -27,4 +27,4 @@ jobs:
   
     - name: Check for docstrings
       run: |
-        ruff check datasets/*/api.py --select D  --ignore D100,D203,D212
+        ruff check datasets/*/api.py --select D  --ignore D100,D203,D213


### PR DESCRIPTION
Previously the configuration for "ruff", which checked docstrings was broken. This should fix it.

Fixes #17 