### PR TITLE
Fix issue #104: Correct typo in action_function dictionary

### DIFF
--- a/scripts/std_to_sft.py
+++ b/scripts/std_to_sft.py
@@ -33,7 +33,7 @@ openhands_default_tools = [
     "edit_file",
 ]
 
-action_function = {"python": "execute_ipython_cell", "bash": "execute_bash", "web": "broswer"}
+action_function = {"python": "execute_ipython_cell", "bash": "execute_bash", "web": "browser"}
 
 function_args = {
     "execute_ipython_cell": "code",

--- a/tests/test_std_to_sft_action_function.py
+++ b/tests/test_std_to_sft_action_function.py
@@ -1,0 +1,21 @@
+import os
+import re
+
+
+def test_action_function_mapping():
+    """Test that the action_function dictionary has correct mappings."""
+    # Read the std_to_sft.py file directly
+    with open(os.path.join("scripts", "std_to_sft.py"), "r") as f:
+        content = f.read()
+
+    # Use regex to find the action_function dictionary definition
+    match = re.search(r"action_function\s*=\s*{([^}]+)}", content)
+    assert match, "Could not find action_function dictionary in std_to_sft.py"
+
+    # Extract the dictionary content
+    dict_content = match.group(1)
+
+    # Check that the web action is correctly spelled as "browser"
+    assert '"web": "browser"' in dict_content, (
+        "Web action should be mapped to 'browser', not 'broswer'"
+    )


### PR DESCRIPTION
This PR fixes issue #104 by correcting a typo in the `action_function` dictionary in `scripts/std_to_sft.py`. The key "web" was mapped to "broswer" instead of "browser".

Changes made:
- Fixed the typo in `scripts/std_to_sft.py`
- Added a test to verify the correct mapping

All tests are passing.

Closes #104

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/{})