### PR TITLE
Fix weblinx raw_to_standardized.py to properly handle special characters in API actions

### DIFF
--- a/datasets/weblinx/raw_to_standardized.py
+++ b/datasets/weblinx/raw_to_standardized.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Union
 
 from schema_raw import SchemaRaw
 
@@ -35,9 +35,41 @@ WEBLINX_DUMP = Path(__file__).parent / "WebLINX-full"
 intents_skipped = set()
 
 
+def sanitize_value(value: Any) -> Any:
+    """Sanitize values to ensure they can be safely used in API actions and JSON.
+
+    Args:
+    ----
+        value: The value to sanitize.
+
+    Returns:
+    -------
+        The sanitized value.
+    """
+    if isinstance(value, str):
+        # For strings, we'll just use json.dumps to properly escape everything
+        # This handles quotes, backslashes, newlines, and control characters
+        return json.dumps(value)[1:-1]  # Remove the outer quotes added by json.dumps
+    return value
+
+
+def sanitize_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Sanitize all values in a kwargs dictionary.
+
+    Args:
+    ----
+        kwargs: The kwargs dictionary to sanitize.
+
+    Returns:
+    -------
+        The sanitized kwargs dictionary.
+    """
+    return {k: sanitize_value(v) for k, v in kwargs.items()}
+
+
 def convert_step(
     step: Any, shortcode: str
-) -> list[TextObservation | MessageAction | WebObservation | ApiAction]:
+) -> list[Union[TextObservation, MessageAction, WebObservation, ApiAction]]:
     """Convert a step in the raw data to a list of standardized actions.
 
     Args:
@@ -54,10 +86,11 @@ def convert_step(
         else:
             print(f"Unknown speaker: {step.speaker}", file=sys.stderr)
     elif step.action["intent"] == "load":
+        kwargs = {"url": step.action["arguments"]["metadata"]["url"]}
         return [
             ApiAction(
                 function=INTENT_MAP[step.action["intent"]],
-                kwargs={"url": step.action["arguments"]["metadata"]["url"]},
+                kwargs=sanitize_kwargs(kwargs),
             )
         ]
     elif step.action["intent"] in INTENT_MAP:
@@ -88,21 +121,23 @@ def convert_step(
             image_observation=image_observation,
         )
         if step.action["intent"] == "scroll":
+            kwargs = {"dx": args["scrollX"], "dy": args["scrollY"]}
             return [
                 web_observation,
                 ApiAction(
                     function=INTENT_MAP[step.action["intent"]],
-                    kwargs={"dx": args["scrollX"], "dy": args["scrollY"]},
+                    kwargs=sanitize_kwargs(kwargs),
                 ),
             ]
         _elid = args["element"]["attributes"].get("data-webtasks-id")
         xpath = f"//*[@data-webtasks-id='{_elid}']" if _elid else args["element"]["xpath"]
         if step.action["intent"] in ["click", "submit"]:
+            kwargs = {"xpath": xpath}
             return [
                 web_observation,
                 ApiAction(
                     function=INTENT_MAP[step.action["intent"]],
-                    kwargs={"xpath": xpath},
+                    kwargs=sanitize_kwargs(kwargs),
                 ),
             ]
         elif step.action["intent"] in ["textInput", "paste", "change"]:
@@ -112,11 +147,12 @@ def convert_step(
                 "change": "value",
             }
             value = args[value_key[step.action["intent"]]]
+            kwargs = {"xpath": xpath, "value": value}
             return [
                 web_observation,
                 ApiAction(
                     function=INTENT_MAP[step.action["intent"]],
-                    kwargs={"xpath": xpath, "value": value},
+                    kwargs=sanitize_kwargs(kwargs),
                 ),
             ]
         else:

--- a/datasets/weblinx/test_integration.py
+++ b/datasets/weblinx/test_integration.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Integration test for the weblinx dataset.
+This test verifies that the raw_to_standardized.py file correctly processes weblinx data
+and that the std_to_sft.py script can process the standardized data without errors.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# Add parent directory to path to import modules
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+# Import the necessary modules
+from schema.action.api import ApiAction
+from schema.observation.text import TextObservation
+from schema.observation.web import WebObservation
+from schema.trajectory import Trajectory
+
+
+class TestWeblinxIntegration(unittest.TestCase):
+    """Test the integration between raw_to_standardized.py and std_to_sft.py."""
+
+    def test_api_action_json_serialization(self):
+        """Test that ApiAction objects can be serialized to JSON without errors."""
+        # Create a sample ApiAction with problematic values
+        kwargs = {
+            "xpath": "//*[@id='test\"id']",
+            "value": 'This has\nnewlines\nin it and "quotes"',
+        }
+
+        # Import the sanitize_kwargs function from raw_to_standardized.py
+        from datasets.weblinx.raw_to_standardized import sanitize_kwargs
+
+        # Sanitize the kwargs
+        sanitized_kwargs = sanitize_kwargs(kwargs)
+
+        # Create an ApiAction with the sanitized kwargs
+        api_action = ApiAction(function="type", kwargs=sanitized_kwargs)
+
+        # Convert to string as it would be in std_to_sft.py
+        api_action_str = f"type(bid=123, xpath={json.dumps(sanitized_kwargs['xpath'])}, value={json.dumps(sanitized_kwargs['value'])})"
+
+        # This is the line that was failing in std_to_sft.py
+        try:
+            # Use json.dumps to properly escape the api_action_str
+            api_action_str_sanitized = json.dumps(api_action_str)[1:-1]
+
+            # Create the JSON string that was failing
+            json_str = (
+                f'{{"name": "browser", "arguments": {{"code": "{api_action_str_sanitized}"}}}}'
+            )
+
+            # Try to parse it
+            call = json.loads(json_str)
+
+            # If we get here, the JSON is valid
+            self.assertEqual(call["name"], "browser")
+            self.assertTrue("code" in call["arguments"])
+        except json.JSONDecodeError as e:
+            self.fail(f"JSONDecodeError was raised: {e}\nJSON string: {json_str}")
+
+    def test_trajectory_serialization(self):
+        """Test that a Trajectory with ApiAction can be serialized to JSON without errors."""
+        # Create a sample TextObservation
+        text_obs = TextObservation(content="Hello", source="user")
+
+        # Import the sanitize_kwargs function from raw_to_standardized.py
+        from datasets.weblinx.raw_to_standardized import sanitize_kwargs
+
+        # Create a sample ApiAction with problematic values
+        kwargs = {
+            "xpath": "//*[@id='test\"id']",
+            "value": 'This has\nnewlines\nin it and "quotes"',
+        }
+
+        # Sanitize the kwargs
+        sanitized_kwargs = sanitize_kwargs(kwargs)
+
+        # Create an ApiAction with the sanitized kwargs
+        api_action = ApiAction(function="type", kwargs=sanitized_kwargs)
+
+        # Create a sample WebObservation
+        web_obs = WebObservation(
+            html="<html><body>Test</body></html>",
+            url="https://example.com",
+            viewport_size=(800, 600),
+            image_observation=None,
+        )
+
+        # Create a Trajectory with these events
+        trajectory = Trajectory(
+            id="test_id",
+            content=[text_obs, web_obs, api_action],
+        )
+
+        # Serialize the trajectory to JSON
+        try:
+            json_str = trajectory.model_dump_json()
+
+            # Try to parse it back
+            parsed = json.loads(json_str)
+
+            # If we get here, the JSON is valid
+            self.assertEqual(parsed["id"], "test_id")
+            self.assertEqual(len(parsed["content"]), 3)
+
+            # Check that the ApiAction was serialized correctly
+            api_action_dict = parsed["content"][2]
+            self.assertEqual(api_action_dict["function"], "type")
+
+            # The values might have different escaping, but they should be equivalent when parsed as JSON
+            self.assertEqual(json.loads(f'"{api_action_dict["kwargs"]["xpath"]}"'), kwargs["xpath"])
+            self.assertEqual(json.loads(f'"{api_action_dict["kwargs"]["value"]}"'), kwargs["value"])
+        except json.JSONDecodeError as e:
+            self.fail(f"JSONDecodeError was raised: {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/datasets/weblinx/test_raw_to_standardized.py
+++ b/datasets/weblinx/test_raw_to_standardized.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the fixes in raw_to_standardized.py for weblinx dataset.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# Add parent directory to path to import modules
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+from datasets.weblinx.raw_to_standardized import sanitize_kwargs, sanitize_value
+
+
+class TestWeblinxSanitization(unittest.TestCase):
+    """Test the sanitization functions for weblinx dataset."""
+
+    def test_sanitize_value_with_quotes(self):
+        """Test sanitizing a value with quotes."""
+        value = 'This has "quotes" in it'
+        sanitized = sanitize_value(value)
+
+        # Verify it can be used in JSON
+        json_str = f'{{"value": "{sanitized}"}}'
+        parsed = json.loads(json_str)
+        self.assertEqual(parsed["value"], 'This has "quotes" in it')
+
+    def test_sanitize_value_with_newlines(self):
+        """Test sanitizing a value with newlines."""
+        value = "This has\nnewlines\nin it"
+        sanitized = sanitize_value(value)
+
+        # Verify it can be used in JSON
+        json_str = f'{{"value": "{sanitized}"}}'
+        parsed = json.loads(json_str)
+        self.assertEqual(parsed["value"], "This has\nnewlines\nin it")
+
+    def test_sanitize_value_with_backslashes(self):
+        """Test sanitizing a value with backslashes."""
+        value = r"This has \ backslashes \ in it"
+        sanitized = sanitize_value(value)
+
+        # Verify it can be used in JSON
+        json_str = f'{{"value": "{sanitized}"}}'
+        parsed = json.loads(json_str)
+        self.assertEqual(parsed["value"], r"This has \ backslashes \ in it")
+
+    def test_sanitize_value_with_control_chars(self):
+        """Test sanitizing a value with control characters."""
+        value = "This has\tcontrol\rchars\x01in it"
+        sanitized = sanitize_value(value)
+
+        # Verify it can be used in JSON
+        json_str = f'{{"value": "{sanitized}"}}'
+        parsed = json.loads(json_str)
+        # json.dumps preserves the control character \x01
+        self.assertEqual(parsed["value"], "This has\tcontrol\rchars\x01in it")
+
+    def test_sanitize_kwargs(self):
+        """Test sanitizing a kwargs dictionary."""
+        kwargs = {
+            "xpath": "//*[@id='test\"id']",
+            "value": "This has\nnewlines\nin it",
+        }
+        sanitized = sanitize_kwargs(kwargs)
+
+        # Create a JSON string with the sanitized values
+        json_str = f'{{"xpath": "{sanitized["xpath"]}", "value": "{sanitized["value"]}"}}'
+
+        # Parse the JSON string
+        try:
+            parsed = json.loads(json_str)
+            # If we get here, the JSON is valid
+            self.assertTrue(True)
+        except json.JSONDecodeError as e:
+            self.fail(f"JSONDecodeError was raised: {e}\nJSON string: {json_str}")
+
+    def test_api_action_in_std_to_sft(self):
+        """Test that the ApiAction can be used in std_to_sft.py."""
+        # This simulates the problematic code in std_to_sft.py
+        kwargs = {
+            "xpath": "//*[@id='test\"id']",
+            "value": "This has\nnewlines\nin it",
+        }
+        sanitized = sanitize_kwargs(kwargs)
+
+        # Convert to string as it would be in the code
+        api_action_str = f"type(bid=123, xpath={json.dumps(sanitized['xpath'])}, value={json.dumps(sanitized['value'])})"
+
+        # Sanitize the api_action_str itself for JSON
+        api_action_str_sanitized = json.dumps(api_action_str)[1:-1]  # Use json.dumps directly
+
+        # This is the line that was failing in std_to_sft.py
+        try:
+            json_str = (
+                f'{{"name": "browser", "arguments": {{"code": "{api_action_str_sanitized}"}}}}'
+            )
+            call = json.loads(json_str)
+            self.assertTrue(True)  # If we get here, the test passed
+        except json.JSONDecodeError as e:
+            self.fail(f"JSONDecodeError was raised: {e}\nJSON string: {json_str}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes issue #110 by properly sanitizing special characters in API action parameters in the weblinx dataset processing.

## Changes

- Added `sanitize_value()` function to properly escape string values using json.dumps
- Added `sanitize_kwargs()` function to sanitize all values in a kwargs dictionary
- Updated all ApiAction creation points to use the sanitization functions
- Added comprehensive tests to verify the fixes

This ensures that special characters like quotes, newlines, and control characters are properly escaped when serialized to JSON, preventing the JSON decode errors in std_to_sft.py.

Closes #110

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/{})