### PR TITLE
Fix finish function to include required message parameter

### DIFF
--- a/datasets/SWE-smith_5kTrajectories/raw_to_standardized.py
+++ b/datasets/SWE-smith_5kTrajectories/raw_to_standardized.py
@@ -3,6 +3,7 @@ import re
 import sys
 
 from schema_raw import SchemaRaw
+
 from schema.action.api import ApiAction
 from schema.action.message import MessageAction
 from schema.observation.text import TextObservation
@@ -14,7 +15,7 @@ def convert_step(step) -> list:
         content = step.content
         # Handle observations that start with "OBSERVATION:"
         if content.startswith("OBSERVATION:"):
-            content = content[len("OBSERVATION:"):].strip()
+            content = content[len("OBSERVATION:") :].strip()
             return [TextObservation(content=content, source="environment")]
         else:
             source = "user" if step.role == "user" else "environment"
@@ -66,9 +67,15 @@ def convert_step(step) -> list:
                     else:
                         kwargs[param_name] = param_value
 
+                # Add required message parameter for finish function if not present
+                if function_name == "finish" and "message" not in kwargs:
+                    kwargs["message"] = "Task completed."
+
                 # Add the API action with description from before_text
                 description = before_text if before_text else None
-                result.append(ApiAction(function=function_name, kwargs=kwargs, description=description))
+                result.append(
+                    ApiAction(function=function_name, kwargs=kwargs, description=description)
+                )
 
                 current_pos = match.end()
 
@@ -91,10 +98,7 @@ def process_data(data):
     for step in data.messages:
         content.extend(convert_step(step))
 
-    return Trajectory(
-        id=data.instance_id, 
-        content=content
-    )
+    return Trajectory(id=data.instance_id, content=content)
 
 
 if __name__ == "__main__":

--- a/datasets/SWE-smith_5kTrajectories/sample_std.json
+++ b/datasets/SWE-smith_5kTrajectories/sample_std.json
@@ -510,7 +510,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": "Perfect! Our fix works for both the original case and the edge cases.\n\n## Summary of changes\n\n1. We added the `is_path_excluded` method to the `Manager` class in the checker.py file:\n   ```python\n   def is_path_excluded(self, path: str) -> bool:\n       \"\"\"Check if a path is excluded based on the exclude patterns.\n\n       :param path:\n           Path to the file to check if it is excluded.\n       :returns:\n           True if the path is excluded, False otherwise.\n       \"\"\"\n       return utils.matches_filename(\n           path,\n           patterns=self.exclude,\n           log_message='\"%(path)s\" has %(whether)sbeen excluded',\n           logger=LOG,\n       )\n   ```\n\n2. We improved the `excluded` method in the `StyleGuide` class in the legacy.py file to handle absolute paths and to check both the original filename and the path with parent:\n   ```python\n   def excluded(self, filename: str, parent: str | None = None) -> bool:\n       \"\"\"Determine if a file is excluded.\n\n       :param filename:\n           Path to the file to check if it is excluded.\n       :param parent:\n           Name of the parent directory containing the file.\n       :returns:\n           True if the filename is excluded, False otherwise.\n       \"\"\"\n       if parent:\n           # If filename is an absolute path, we should still check it with the parent\n           # by using the basename of the file\n           if os.path.isabs(filename):\n               base_filename = os.path.basename(filename)\n               path_to_check = os.path.join(parent, base_filename)\n           else:\n               path_to_check = os.path.join(parent, filename)\n           \n           # Check both the original filename and the path with parent\n           return (self._file_checker_manager.is_path_excluded(filename) or \n                   self._file_checker_manager.is_path_excluded(path_to_check))\n       return self._file_checker_manager.is_path_excluded(filename)\n   ```\n\nThese changes ensure that the `excluded` method in the `StyleGuide` class correctly handles parent directory exclusions, including edge cases like absolute paths, empty parent directories, and paths with separators.\n\nLet's submit our solution:"
       },
       {
@@ -534,7 +536,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": null
       }
     ],
@@ -770,7 +774,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": "Great! Our implementation correctly handles a valid env file as well. It reads the values from the file and uses them when available, falls back to default values when provided, and raises a KeyError when a key is missing and no default is provided.\n\nLet's summarize the changes we made:\n\n1. We imported the `warnings` module to be able to emit warnings.\n2. We changed the behavior of the `Config` class when an environment file doesn't exist:\n   - Instead of raising a `FileNotFoundError`, it now emits a warning.\n   - It continues execution with an empty `file_values` dictionary.\n\nThese changes ensure that the code behaves as described in the PR description, allowing applications to continue running even if the config file is missing, which is especially useful in development environments."
       },
       {
@@ -794,7 +800,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": null
       }
     ],
@@ -1527,7 +1535,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": "Great! All the edge cases are handled correctly. Our fix is robust and handles all the scenarios mentioned in the PR description.\n\n## Summary of changes\n\nHere's a summary of the changes we made to fix the SQL parsing issues:\n\n1. Changed the regex flags from `re.MULTILINE` to `re.IGNORECASE` in the `set_SQL_REGEX` method to properly match SQL keywords regardless of case.\n2. Fixed the `is_keyword` method to correctly check for keywords by using `upper()` instead of `lower()` and returning the correct token type.\n3. Fixed the encoding handling in the `get_tokens` method to correctly decode binary input using `decode()` instead of `encode()` and using 'utf-8' as the default encoding.\n4. Completely rewrote the tokenization logic in the `get_tokens` method to correctly match and consume tokens, fixing the off-by-one error.\n5. Fixed the initialization of `_keywords` in the `clear` method to use an empty list `[]` instead of an empty dict `{}`.\n\nThese changes ensure that SQL parsing works correctly for all the scenarios mentioned in the PR description, including:\n- Proper keyword recognition\n- Correct case handling\n- Proper token matching and consumption\n- Correct string encoding when handling binary input\n\nLet's submit our solution:"
       },
       {
@@ -1551,7 +1561,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": null
       }
     ],
@@ -2729,7 +2741,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": "Since we have successfully fixed the issue and verified it works, let's submit the changes:"
       }
     ],
@@ -3140,7 +3154,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": "Great! All the edge cases are working correctly:\n\n1. Different timezone: The timezone information is preserved\n2. No timezone: Works correctly with no timezone\n3. Empty array: Works correctly with an empty array\n4. Array with NaT values: The timezone information is preserved, and NaT values are handled correctly\n5. Different extension array type: Works correctly with a Categorical array\n\n## Summary\n\nThe issue was in the `value_counts` method of the `NDArrayBackedExtensionArray` class, where the code was executed in the wrong order. The method was trying to use the `result` variable before it was defined.\n\nThe fix was to reorder the code in the method to:\n1. First, check if the array is 1-dimensional\n2. Import the necessary classes\n3. Prepare the values based on the `dropna` parameter\n4. Call the `value_counts` function to get the result\n5. Create a new index with the correct type (preserving timezone information)\n6. Return the Series with the correct index\n\nThis ensures that the timezone information is preserved in the result's index, which was the main issue described in the PR description.\n\nThe fix is minimal and focused on the specific issue, without modifying any test files. It also handles various edge cases correctly, including different timezones, no timezone, empty arrays, arrays with NaT values, and different extension array types."
       },
       {
@@ -3164,7 +3180,9 @@
       {
         "class_": "api_action",
         "function": "finish",
-        "kwargs": {},
+        "kwargs": {
+          "message": "Task completed."
+        },
         "description": null
       }
     ],


### PR DESCRIPTION
## Description
This PR fixes the failing GitHub Actions on PR #131 by ensuring that the `finish` function always has the required `message` parameter.

### Changes Made
1. Modified `raw_to_standardized.py` in the SWE-smith_5kTrajectories dataset to add a default `message` parameter when it's missing:
   ```python
   # Add required message parameter for finish function if not present
   if function_name == "finish" and "message" not in kwargs:
       kwargs["message"] = "Task completed."
   ```

2. Updated the `sample_std.json` file to include the required `message` parameter for all instances of the `finish` function.

### Testing
- All pre-commit checks now pass successfully.
- The Python tests for the SWE-smith_5kTrajectories dataset now pass successfully.

This PR resolves the issue where the `finish` function was missing the required `message` parameter, which was causing the GitHub Actions to fail.