### PR TITLE
Add warning that webarena_successful is test data

### DIFF
--- a/datasets/webarena_successful/README.md
+++ b/datasets/webarena_successful/README.md
@@ -1,3 +1,6 @@
+# ⚠️ WARNING: TEST DATA - DO NOT TRAIN ON THIS DATASET ⚠️
+This dataset contains test trajectories and should NOT be used for training purposes.
+
 # Description
 Successful trajectories from different models
 


### PR DESCRIPTION
This PR adds a prominent warning at the top of the README for the webarena_successful dataset, clearly indicating that it contains test data and should not be used for training purposes.

The warning is displayed with attention-grabbing emoji and clear text to ensure it's not overlooked.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6140ce2a41aa467fb93b9993f219edfe)