### PR TITLE
Add per-step reward field to Action and Observation schemas

### DIFF
--- a/schema/SCHEMA.md
+++ b/schema/SCHEMA.md
@@ -31,9 +31,10 @@ Actions represent steps taken by an agent during task execution.
 
 Base Class Implementation: [`schema/action/action.py`](../schema/action/action.py)
 
-All action types inherit from the base `Action` class which provides a common field:
+All action types inherit from the base `Action` class which provides common fields:
 
 - `reasoning_content` (str, optional): Extended chain-of-thought reasoning or internal thinking from the agent. This captures deliberate reasoning processes (e.g., `<think>` blocks) that are separate from the action's brief description. This field aligns with Harbor ATIF's `reasoning_content` field and Agent Client Protocol's `agent_thought_chunk` concept.
+- `reward` (float, optional): Per-step reward signal associated with this action. Used for capturing rewards earned during reinforcement learning training and evaluation.
 
 #### ApiAction
 
@@ -81,6 +82,10 @@ Represents communication/messages from the agent.
 Observations represent information received by the agent from its environment.
 
 Base Observation Implementation: [`schema/observation/observation.py`](../schema/observation/observation.py)
+
+All observation types inherit from the base `Observation` class which provides a common field:
+
+- `reward` (float, optional): Per-step reward signal associated with this observation. Used for reinforcement learning training data.
 
 #### TextObservation
 

--- a/schema/action/action.py
+++ b/schema/action/action.py
@@ -9,3 +9,8 @@ class Action(BaseModel):
         "from the action's brief description. Aligns with Harbor ATIF's reasoning_content field "
         "and Agent Client Protocol's agent_thought_chunk concept.",
     )
+    reward: float | None = Field(
+        None,
+        description="Per-step reward signal associated with this action. "
+        "Used for reinforcement learning training data.",
+    )

--- a/schema/observation/observation.py
+++ b/schema/observation/observation.py
@@ -1,5 +1,9 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Observation(BaseModel):
-    pass
+    reward: float | None = Field(
+        None,
+        description="Per-step reward signal associated with this observation. "
+        "Used for reinforcement learning training data.",
+    )


### PR DESCRIPTION
## Summary

- Adds an optional `reward: float | None` field to the base `Action` class (`schema/action/action.py`), inherited by `ApiAction`, `CodeAction`, and `MessageAction`
- Adds an optional `reward: float | None` field to the base `Observation` class (`schema/observation/observation.py`), inherited by `TextObservation`, `WebObservation`, and `ImageObservation`
- Updates `schema/SCHEMA.md` to document the new field on both base classes

## Motivation

ADP currently has no mechanism to attach reward signals to individual trajectory steps. This makes it difficult to use ADP-formatted data for reinforcement learning, where per-step rewards are a core primitive.

This change adds `reward` as a first-class optional field on every action and observation, allowing datasets to record the reward received at each step of a trajectory. It's conceivable that some RL settings may provide reward with an observation or at action time, this change supports both approaches.

## Design notes

- `reward` defaults to `None` — fully backwards-compatible, all existing `sample_std.json` files validate without modification
- Modelled as a plain `float` scalar (not a distribution or vector) to keep the schema simple and composable

## Tests

- [x] `pytest tests/test_standardized_schemas.py` — all 33 datasets pass
- [x] Full test suite — 136 passed, 0 failures

I don't think new tests are required by this but happy to add if useful.