### PR TITLE
Make PR review LLM endpoint configurable

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Run PR Review
         uses: OpenHands/extensions/plugins/pr-review@main
         with:
-          llm-model: litellm_proxy/claude-sonnet-4-5-20250929
-          llm-base-url: https://llm-proxy.app.all-hands.dev
+          llm-model: ${{ vars.LLM_MODEL || 'litellm_proxy/claude-sonnet-4-5-20250929' }}
+          llm-base-url: ${{ vars.LLM_BASE_URL || 'https://llm-proxy.app.all-hands.dev' }}
           use-sub-agents: 'false'
           require-evidence: 'true'
           llm-api-key: ${{ secrets.LLM_API_KEY }}


### PR DESCRIPTION
## Summary
- Read the PR review model from `vars.LLM_MODEL` with the existing model as a fallback.
- Read the PR review base URL from `vars.LLM_BASE_URL` with the existing OpenHands proxy URL as a fallback.
- Continue reading the API key from `secrets.LLM_API_KEY`.

## Why
This lets maintainers configure the LLM endpoint without editing the workflow file, while preserving current defaults for repositories that do not define variables.

## Validation
- Verified the workflow contains `vars.LLM_MODEL`, `vars.LLM_BASE_URL`, and `secrets.LLM_API_KEY`.
- Checked that the workflow file contains no tab indentation.

This PR was created by an AI agent (OpenHands) on behalf of the user.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/248118d2-5d98-47e8-ba10-df4233affe87)