### PR TITLE
Preserve OpenHands tool roles in SFT conversion

### DIFF
--- a/agents/openhands/std_to_sft.py
+++ b/agents/openhands/std_to_sft.py
@@ -298,11 +298,6 @@ def process_row(line, is_web, api_env, api_tool_description, api_sigs):
     if languages:
         language_descriptions = get_language_descriptions(languages)
         conversations[0]["value"] = language_descriptions + "\n\n" + conversations[0]["value"]
-    for m in conversations:
-        if m["from"] == "function_call":
-            m["from"] = "gpt"
-        if m["from"] == "observation":
-            m["from"] = "human"
     return {
         "id": trajectory.id,
         "conversations": conversations,

--- a/tests/test_openhands_sft_role_preservation.py
+++ b/tests/test_openhands_sft_role_preservation.py
@@ -1,0 +1,89 @@
+import importlib
+import json
+import sys
+import types
+
+
+def import_openhands_converter(monkeypatch):
+    """Import std_to_sft without constructing the browsergym environment."""
+    monkeypatch.setenv("MY_DATASET", "role_preservation_test")
+
+    fake_html_module = types.ModuleType("scripts.html_to_axtree")
+
+    class FakeHTMLToAXTree:
+        def __init__(self, dataset):
+            self.dataset = dataset
+            self.last_html = None
+            self.last_xtree = None
+
+        def build_axtree(self, id, html_content, chunk):
+            self.last_html = html_content
+            self.last_xtree = ""
+            return ""
+
+        def get_bid(self, id, x_path, chunk):
+            return None
+
+    fake_html_module.HTMLToAXTree = FakeHTMLToAXTree
+    monkeypatch.setitem(sys.modules, "scripts.html_to_axtree", fake_html_module)
+
+    fake_system_module = types.ModuleType("agents.openhands.system_prompt.system")
+    fake_system_module.get_system_message = lambda: "system prompt"
+    monkeypatch.setitem(sys.modules, "agents.openhands.system_prompt.system", fake_system_module)
+
+    fake_user_module = types.ModuleType("agents.openhands.system_prompt.user")
+    fake_user_module.get_web_user_message = lambda *args, **kwargs: "web prompt"
+    monkeypatch.setitem(sys.modules, "agents.openhands.system_prompt.user", fake_user_module)
+
+    monkeypatch.delitem(sys.modules, "agents.openhands.std_to_sft", raising=False)
+    return importlib.import_module("agents.openhands.std_to_sft")
+
+
+def test_openhands_converter_preserves_tool_roles(monkeypatch):
+    converter = import_openhands_converter(monkeypatch)
+    line = json.dumps(
+        {
+            "id": "role-preservation",
+            "content": [
+                {
+                    "class_": "text_observation",
+                    "content": "Run pwd.",
+                    "source": "user",
+                },
+                {
+                    "class_": "code_action",
+                    "language": "bash",
+                    "content": "pwd",
+                    "description": None,
+                },
+                {
+                    "class_": "text_observation",
+                    "content": "/workspace/project",
+                    "source": "environment",
+                },
+                {
+                    "class_": "message_action",
+                    "content": "Done.",
+                    "description": None,
+                },
+            ],
+        }
+    )
+
+    result = converter.process_row(
+        line,
+        is_web=False,
+        api_env=None,
+        api_tool_description="",
+        api_sigs={},
+    )
+
+    conversations = result["conversations"]
+    assert [message["from"] for message in conversations] == [
+        "human",
+        "function_call",
+        "observation",
+        "gpt",
+    ]
+    assert "<function=execute_bash>" in conversations[1]["value"]
+    assert conversations[2]["value"].startswith("EXECUTION RESULT of [execute_bash]:")


### PR DESCRIPTION
## Summary
- Preserve `function_call` and `observation` roles in `agents/openhands/std_to_sft.py` instead of collapsing them to `gpt`/`human`.
- Add a focused regression test that exercises a real converter path and asserts the role sequence remains `human -> function_call -> observation -> gpt`.

## Rationale
The repository guidelines require messages containing function-call syntax such as `<function=` to use `"from": "function_call"`. LLaMA-Factory ShareGPT tool-call format also supports `function_call` and `observation` roles directly, so collapsing these roles loses tool-call semantics and makes generated samples inconsistent with ADP conventions.

## Tests run
```bash
python -m pytest tests/test_openhands_sft_role_preservation.py -v
python -m ruff check agents/openhands/std_to_sft.py tests/test_openhands_sft_role_preservation.py
python -m pytest tests/test_std_to_sft_conversion.py tests/test_sft_quality_control.py tests/test_openhands_sft_role_preservation.py -q
```

Result: `29 passed, 12 skipped` for the combined SFT-related pytest run.

## Evidence

Ran the converter against an existing real standardized sample from `datasets/agenttuning_alfworld/sample_std.json` and printed the first generated roles:

```bash
PYTHONPATH=$PWD MY_DATASET=agenttuning_alfworld python - <<'PY'
import importlib
import json
import sys
import types

fake_html_module = types.ModuleType('scripts.html_to_axtree')
class FakeHTMLToAXTree:
    def __init__(self, dataset): pass
    def build_axtree(self, id, html_content, chunk): return ''
    def get_bid(self, id, x_path, chunk): return None
fake_html_module.HTMLToAXTree = FakeHTMLToAXTree
sys.modules['scripts.html_to_axtree'] = fake_html_module

fake_system_module = types.ModuleType('agents.openhands.system_prompt.system')
fake_system_module.get_system_message = lambda: 'system prompt'
sys.modules['agents.openhands.system_prompt.system'] = fake_system_module
fake_user_module = types.ModuleType('agents.openhands.system_prompt.user')
fake_user_module.get_web_user_message = lambda *args, **kwargs: 'web prompt'
sys.modules['agents.openhands.system_prompt.user'] = fake_user_module

converter = importlib.import_module('agents.openhands.std_to_sft')
row = json.load(open('datasets/agenttuning_alfworld/sample_std.json'))[0]
result = converter.process_line(json.dumps(row), is_web=False, api_env='execute_ipython_cell')
roles = [message['from'] for message in json.loads(result)['conversations'][:8]]
print('\n'.join(roles))
PY
```

Output:

```text
human
gpt
human
function_call
observation
function_call
observation
function_call
```

This demonstrates that the shared converter now preserves the tool-call and tool-result roles for a real dataset sample instead of collapsing them to `gpt`/`human`. The lightweight import stubs avoid constructing the browsergym environment in this local Python 3.13 runtime; the tested conversion path is still `process_line` on a committed ADP standardized sample.

This PR was created by an AI agent (OpenHands) on behalf of the user.
