### PR TITLE
Make OpenHands browser tools optional for non-web datasets

### DIFF
--- a/agents/openhands/std_to_sft.py
+++ b/agents/openhands/std_to_sft.py
@@ -19,11 +19,20 @@ from schema.action.message import MessageAction
 from schema.observation.text import TextObservation
 from schema.observation.web import WebObservation
 from schema.trajectory import Trajectory
-from scripts.html_to_axtree import HTMLToAXTree
 
 dataset = os.getenv("MY_DATASET")
 assert dataset, "Please set the environment variable MY_DATASET"
-generate_axtree = HTMLToAXTree(dataset)
+generate_axtree = None
+
+
+def get_generate_axtree():
+    global generate_axtree
+    if generate_axtree is None:
+        from scripts.html_to_axtree import HTMLToAXTree
+
+        generate_axtree = HTMLToAXTree(dataset)
+    return generate_axtree
+
 
 action_function = {"python": "execute_ipython_cell", "bash": "execute_bash", "web": "browser"}
 function_args = {"execute_ipython_cell": "code", "execute_bash": "command", "browser": "code"}
@@ -84,12 +93,13 @@ def standardized_event_to_openhands_message(
 ) -> dict:
     global PREV_BID
     if isinstance(event, WebObservation):
+        html_to_axtree = get_generate_axtree()
         if event.axtree is not None:
             axtree = event.axtree
-        elif generate_axtree.last_html != event.html:
-            axtree = generate_axtree.build_axtree(id, event.html, "all")
+        elif html_to_axtree.last_html != event.html:
+            axtree = html_to_axtree.build_axtree(id, event.html, "all")
         else:
-            axtree = generate_axtree.last_xtree
+            axtree = html_to_axtree.last_xtree
         prompt = get_web_user_message("", event.url, axtree, PREV_BID)
         return {"from": "human", "value": prompt}
 
@@ -132,7 +142,7 @@ def standardized_event_to_openhands_message(
         if not browsergym_id:
             event_xpath = event.kwargs.get("xpath", None)
             if event_xpath:
-                browsergym_id = generate_axtree.get_bid(id, event_xpath, "all")
+                browsergym_id = get_generate_axtree().get_bid(id, event_xpath, "all")
         # for tool calls that are not browser based since there is no browsergym_id
         # and tool calls that are specified as non-web
         # these should all be dataset specific apis
@@ -303,7 +313,7 @@ def process_row(line, is_web, api_env, api_tool_description, api_sigs):
     return {
         "id": trajectory.id,
         "conversations": conversations,
-        "system": get_system_message(),
+        "system": get_system_message(codeact_enable_browsing=is_web),
     }
 
 

--- a/agents/openhands/system_prompt/system.py
+++ b/agents/openhands/system_prompt/system.py
@@ -1,15 +1,12 @@
 import os
 
-from agents.openhands.system_prompt.tools import (
-    BrowserTool,
-    FinishTool,
-    IPythonTool,
-    LLMBasedFileEditTool,
-    ThinkTool,
-    WebReadTool,
-    create_cmd_run_tool,
-    create_str_replace_editor_tool,
-)
+from agents.openhands.system_prompt.tools.bash import create_cmd_run_tool
+from agents.openhands.system_prompt.tools.finish import FinishTool
+from agents.openhands.system_prompt.tools.ipython import IPythonTool
+from agents.openhands.system_prompt.tools.llm_based_edit import LLMBasedFileEditTool
+from agents.openhands.system_prompt.tools.str_replace_editor import create_str_replace_editor_tool
+from agents.openhands.system_prompt.tools.think import ThinkTool
+from agents.openhands.system_prompt.tools.web_read import WebReadTool
 
 _script_dir = os.path.dirname(os.path.realpath(__file__))
 prompt_file = os.path.join(_script_dir, "system_prefix.txt")
@@ -55,6 +52,8 @@ def get_tools(
         FinishTool,
     ]
     if codeact_enable_browsing:
+        from agents.openhands.system_prompt.tools.browser import BrowserTool
+
         tools.append(WebReadTool)
         tools.append(BrowserTool)
     if codeact_enable_jupyter:

--- a/agents/openhands/system_prompt/tools/__init__.py
+++ b/agents/openhands/system_prompt/tools/__init__.py
@@ -1,5 +1,12 @@
 from .bash import create_cmd_run_tool
-from .browser import BrowserTool
+
+try:
+    from .browser import BrowserTool
+except ModuleNotFoundError as exc:
+    if not (exc.name or "").startswith("browsergym"):
+        raise
+    BrowserTool = None
+
 from .finish import FinishTool
 from .ipython import IPythonTool
 from .llm_based_edit import LLMBasedFileEditTool

--- a/tests/test_openhands_sft_role_preservation.py
+++ b/tests/test_openhands_sft_role_preservation.py
@@ -28,7 +28,7 @@ def import_openhands_converter(monkeypatch):
     monkeypatch.setitem(sys.modules, "scripts.html_to_axtree", fake_html_module)
 
     fake_system_module = types.ModuleType("agents.openhands.system_prompt.system")
-    fake_system_module.get_system_message = lambda: "system prompt"
+    fake_system_module.get_system_message = lambda *args, **kwargs: "system prompt"
     monkeypatch.setitem(sys.modules, "agents.openhands.system_prompt.system", fake_system_module)
 
     fake_user_module = types.ModuleType("agents.openhands.system_prompt.user")

--- a/tests/test_optional_browser.py
+++ b/tests/test_optional_browser.py
@@ -1,0 +1,58 @@
+"""Regression test: the OpenHands SFT pipeline must import cleanly without browsergym.
+
+`agents/openhands/system_prompt/tools/__init__.py` wraps the `BrowserTool` import in
+`try/except ModuleNotFoundError` so that converters for non-web datasets work on
+environments that have not installed `browsergym`. This test simulates that
+condition by injecting a meta-path finder that raises ModuleNotFoundError for any
+`browsergym*` import, then reloads the affected modules.
+"""
+
+import importlib
+import sys
+
+
+class _BlockBrowserGym:
+    """Meta-path finder that pretends browsergym is uninstalled."""
+
+    def find_module(self, name, path=None):  # py<3.4-compatible API still honored
+        if name.startswith("browsergym"):
+            return self
+        return None
+
+    def load_module(self, name):  # pragma: no cover - exercised via import machinery
+        raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+
+
+def _reload_target_modules():
+    for name in list(sys.modules):
+        if (
+            name.startswith("browsergym")
+            or name.startswith("agents.openhands.system_prompt.tools")
+            or name == "agents.openhands.system_prompt.system"
+        ):
+            del sys.modules[name]
+
+
+def test_tools_init_handles_missing_browsergym():
+    finder = _BlockBrowserGym()
+    sys.meta_path.insert(0, finder)
+    try:
+        _reload_target_modules()
+        tools = importlib.import_module("agents.openhands.system_prompt.tools")
+        assert tools.BrowserTool is None
+    finally:
+        sys.meta_path.remove(finder)
+        _reload_target_modules()
+
+
+def test_get_system_message_without_browsing_omits_browser_tools():
+    finder = _BlockBrowserGym()
+    sys.meta_path.insert(0, finder)
+    try:
+        _reload_target_modules()
+        system = importlib.import_module("agents.openhands.system_prompt.system")
+        message = system.get_system_message(codeact_enable_browsing=False)
+        assert "BrowserTool" not in message
+    finally:
+        sys.meta_path.remove(finder)
+        _reload_target_modules()

--- a/tests/test_optional_browser.py
+++ b/tests/test_optional_browser.py
@@ -14,6 +14,10 @@ not be installed in the test environment; reloading them through an
 in-process patch is brittle. The subprocess inherits the parent
 interpreter and PYTHONPATH so the test still runs against the actual
 repository code, but it gets a clean import graph each time.
+
+The finder uses the modern PEP 451 `find_spec` / `exec_module`
+protocol so this test stays forward-compatible with Python versions
+that drop the legacy PEP 302 `find_module` / `load_module` interface.
 """
 
 import os
@@ -40,17 +44,23 @@ def _run_block_browsergym_subprocess(script: str) -> subprocess.CompletedProcess
 
 _BLOCK_BROWSERGYM_PREAMBLE = textwrap.dedent(
     """
+    import importlib.machinery
     import sys
 
 
     class _BlockBrowserGym:
-        def find_module(self, name, path=None):
-            if name.startswith("browsergym"):
-                return self
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname.startswith("browsergym"):
+                return importlib.machinery.ModuleSpec(fullname, self)
             return None
 
-        def load_module(self, name):
-            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            raise ModuleNotFoundError(
+                f"No module named {module.__name__!r}", name=module.__name__
+            )
 
 
     sys.meta_path.insert(0, _BlockBrowserGym())
@@ -64,6 +74,15 @@ def test_tools_init_handles_missing_browsergym():
         _BLOCK_BROWSERGYM_PREAMBLE
         + textwrap.dedent(
             """
+            # Sanity-check that the meta_path finder actually fires
+            try:
+                import browsergym  # noqa: F401
+                raise AssertionError(
+                    "browsergym should have been blocked by the meta_path finder"
+                )
+            except ModuleNotFoundError:
+                pass
+
             from agents.openhands.system_prompt import tools
 
             assert tools.BrowserTool is None, (

--- a/tests/test_optional_browser.py
+++ b/tests/test_optional_browser.py
@@ -1,58 +1,103 @@
-"""Regression test: the OpenHands SFT pipeline must import cleanly without browsergym.
+"""Regression test for #213: OpenHands tool imports must tolerate a missing browsergym.
 
-`agents/openhands/system_prompt/tools/__init__.py` wraps the `BrowserTool` import in
-`try/except ModuleNotFoundError` so that converters for non-web datasets work on
-environments that have not installed `browsergym`. This test simulates that
-condition by injecting a meta-path finder that raises ModuleNotFoundError for any
-`browsergym*` import, then reloads the affected modules.
+`agents/openhands/system_prompt/tools/__init__.py` wraps the `BrowserTool`
+re-export in `try/except ModuleNotFoundError` so that converters for
+non-web datasets work on environments that have not installed
+`browsergym`. We exercise that path by running a subprocess with a
+`sys.meta_path` finder that raises `ModuleNotFoundError` for every
+`browsergym*` import.
+
+The subprocess is used (rather than monkeypatching the in-process
+import system) because the tool modules import third-party packages
+such as `litellm` at module load time, and those packages may or may
+not be installed in the test environment; reloading them through an
+in-process patch is brittle. The subprocess inherits the parent
+interpreter and PYTHONPATH so the test still runs against the actual
+repository code, but it gets a clean import graph each time.
 """
 
-import importlib
+import os
+import subprocess
 import sys
+import textwrap
+
+import pytest
 
 
-class _BlockBrowserGym:
-    """Meta-path finder that pretends browsergym is uninstalled."""
+def _run_block_browsergym_subprocess(script: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+    env["MY_DATASET"] = "optional_browser_test"
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
-    def find_module(self, name, path=None):  # py<3.4-compatible API still honored
-        if name.startswith("browsergym"):
-            return self
-        return None
 
-    def load_module(self, name):  # pragma: no cover - exercised via import machinery
-        raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+_BLOCK_BROWSERGYM_PREAMBLE = textwrap.dedent(
+    """
+    import sys
 
 
-def _reload_target_modules():
-    for name in list(sys.modules):
-        if (
-            name.startswith("browsergym")
-            or name.startswith("agents.openhands.system_prompt.tools")
-            or name == "agents.openhands.system_prompt.system"
-        ):
-            del sys.modules[name]
+    class _BlockBrowserGym:
+        def find_module(self, name, path=None):
+            if name.startswith("browsergym"):
+                return self
+            return None
+
+        def load_module(self, name):
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+
+
+    sys.meta_path.insert(0, _BlockBrowserGym())
+    """
+)
 
 
 def test_tools_init_handles_missing_browsergym():
-    finder = _BlockBrowserGym()
-    sys.meta_path.insert(0, finder)
-    try:
-        _reload_target_modules()
-        tools = importlib.import_module("agents.openhands.system_prompt.tools")
-        assert tools.BrowserTool is None
-    finally:
-        sys.meta_path.remove(finder)
-        _reload_target_modules()
+    pytest.importorskip("litellm")
+    result = _run_block_browsergym_subprocess(
+        _BLOCK_BROWSERGYM_PREAMBLE
+        + textwrap.dedent(
+            """
+            from agents.openhands.system_prompt import tools
+
+            assert tools.BrowserTool is None, (
+                f"BrowserTool should be None when browsergym is unavailable, "
+                f"got {tools.BrowserTool!r}"
+            )
+            print("OK")
+            """
+        )
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
 
 
 def test_get_system_message_without_browsing_omits_browser_tools():
-    finder = _BlockBrowserGym()
-    sys.meta_path.insert(0, finder)
-    try:
-        _reload_target_modules()
-        system = importlib.import_module("agents.openhands.system_prompt.system")
-        message = system.get_system_message(codeact_enable_browsing=False)
-        assert "BrowserTool" not in message
-    finally:
-        sys.meta_path.remove(finder)
-        _reload_target_modules()
+    pytest.importorskip("litellm")
+    result = _run_block_browsergym_subprocess(
+        _BLOCK_BROWSERGYM_PREAMBLE
+        + textwrap.dedent(
+            """
+            from agents.openhands.system_prompt.system import get_system_message
+
+            message = get_system_message(codeact_enable_browsing=False)
+            assert "BrowserTool" not in message, (
+                "get_system_message(codeact_enable_browsing=False) must not "
+                "advertise BrowserTool"
+            )
+            print("OK")
+            """
+        )
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Summary

Extract the lazy-import refactor that was previously duplicated inside PRs #193 (CodeScout) and #197 (jupyter-agent) into its own change so those PRs can revert to dataset-only diffs.

## Motivation

Non-web datasets (CodeScout, jupyter-agent, etc.) currently cannot run `agents/openhands/std_to_sft.py` on environments that do not have `browsergym` installed, because:

- `agents/openhands/system_prompt/tools/__init__.py` does an unconditional `from .browser import BrowserTool` and `browser.py` imports `browsergym` at module load.
- `agents/openhands/std_to_sft.py` constructs `HTMLToAXTree(dataset)` at module load even when the dataset has no `WebObservation` events.

The fix is to defer browser-related imports until they are actually needed.

## Changes

- **`agents/openhands/system_prompt/tools/__init__.py`** — Wrap the `BrowserTool` re-export in `try/except ModuleNotFoundError`. The handler only swallows the error when the missing module is `browsergym` (or a submodule); any other ImportError still propagates. `BrowserTool` is bound to `None` when `browsergym` is unavailable.
- **`agents/openhands/system_prompt/system.py`** — Switch the top-level tool imports from the package `__init__` to their direct submodules so module load no longer touches `browser.py`. Defer `from agents.openhands.system_prompt.tools.browser import BrowserTool` to inside the `if codeact_enable_browsing:` branch of `get_tools`.
- **`agents/openhands/std_to_sft.py`** — Lazy-load `scripts.html_to_axtree.HTMLToAXTree` behind a `get_generate_axtree()` helper; it is only constructed when a `WebObservation` event is actually encountered. Also thread the existing `--is_web` CLI flag into `get_system_message(codeact_enable_browsing=is_web)` so non-web datasets actually get a non-web system prompt (today the default `True` is always used).
- **`tests/test_openhands_sft_role_preservation.py`** — Loosen the fake `get_system_message` to `*args, **kwargs` to accept the new keyword argument.
- **`tests/test_optional_browser.py`** *(new)* — Regression test (skipped when `litellm` is absent) that installs a `sys.meta_path` finder which raises `ModuleNotFoundError` for any `browsergym*` import, then asserts (a) `agents.openhands.system_prompt.tools` imports cleanly with `BrowserTool is None` and (b) `get_system_message(codeact_enable_browsing=False)` returns a prompt that does not advertise `BrowserTool`.

## Validation

`python -m pytest tests/` → 183 passed, 12 skipped, 4 warnings.

## Evidence — end-to-end conversion of a non-web dataset without browsergym

Driver script (full source below): installs a `sys.meta_path` finder that raises `ModuleNotFoundError` for any `browsergym*` import, sets `MY_DATASET=codeactinstruct` (a non-web dataset already in the repo), imports the production `agents.openhands.std_to_sft` module, and calls `main_with_args(line, is_web=False, api_env=None)` on one record from `datasets/codeactinstruct/sample_std.json`.

### Control run — on `main` (without this PR)

```
[sanity] browsergym blocked as expected: No module named 'browsergym'
Traceback (most recent call last):
  ...
  File ".../agents/openhands/std_to_sft.py", line 14, in <module>
    from agents.openhands.system_prompt.system import get_system_message
  File ".../agents/openhands/system_prompt/system.py", line 3, in <module>
    from agents.openhands.system_prompt.tools import (
  File ".../agents/openhands/system_prompt/tools/__init__.py", line 2, in <module>
    from .browser import BrowserTool
  File ".../agents/openhands/system_prompt/tools/browser.py", line 1, in <module>
    from browsergym.core.action.highlevel import HighLevelActionSet
ModuleNotFoundError: No module named 'browsergym'
```

→ The pipeline fails to import; converter is unusable.

### Treatment run — on this branch (`refactor-optional-browser`)

```
[sanity] browsergym blocked as expected: No module named 'browsergym'
OK: produced SFT record with 8 conversation turns
system prompt length: 13399 chars (browser tools omitted)
```

→ The pipeline runs to completion, returns a well-formed SFT record (verified via `json.loads` + structural assertions on `conversations`/`system`), and the system prompt does not advertise `BrowserTool` (asserted in the driver).

### Driver script

```python
"""Driver: block any browsergym import (PEP 451 finder), then run std_to_sft on one record."""
import importlib.machinery
import sys


class _BlockBrowserGym:
    def find_spec(self, fullname, path=None, target=None):
        if fullname.startswith("browsergym"):
            return importlib.machinery.ModuleSpec(fullname, self)
        return None

    def create_module(self, spec):
        return None

    def exec_module(self, module):
        raise ModuleNotFoundError(
            f"No module named {module.__name__!r}", name=module.__name__
        )


sys.meta_path.insert(0, _BlockBrowserGym())

try:
    import browsergym  # noqa: F401
    print("UNEXPECTED: browsergym imported successfully", file=sys.stderr)
    sys.exit(99)
except ModuleNotFoundError as e:
    print(f"[sanity] browsergym blocked as expected: {e}", file=sys.stderr)

import os
os.environ["MY_DATASET"] = "codeactinstruct"

import importlib
std_to_sft = importlib.import_module("agents.openhands.std_to_sft")

import json
with open("datasets/codeactinstruct/sample_std.json") as f:
    sample = json.load(f)
record_line = json.dumps(sample[0])
out = std_to_sft.main_with_args(record_line, is_web=False, api_env=None)
if not out:
    print("FAIL: std_to_sft.main_with_args returned no output", file=sys.stderr)
    sys.exit(1)
parsed = json.loads(out)
assert "conversations" in parsed and isinstance(parsed["conversations"], list)
assert "system" in parsed
assert "BrowserTool" not in parsed["system"], "system prompt unexpectedly mentions BrowserTool"
print(f"OK: produced SFT record with {len(parsed['conversations'])} conversation turns")
print(f"system prompt length: {len(parsed['system'])} chars (browser tools omitted)")
```

## Follow-up

Once this is merged, PRs #193 and #197 will be rebased onto `main` to drop their copies of these four files; their diffs should then contain only their respective `datasets/` directory plus the `README.md`/`agents/openhands/DATASETS.md` catalog entries (already done — see https://github.com/neulab/agent-data-protocol/pull/197 and https://github.com/neulab/agent-data-protocol/pull/193).

---
_This PR was prepared by an AI agent (OpenHands) on behalf of the user. Originating conversation context is available to the requester._
