### PR TITLE
Make converter terminal messages deterministic

### DIFF
--- a/datasets/agenttuning_alfworld/raw_to_standardized.py
+++ b/datasets/agenttuning_alfworld/raw_to_standardized.py
@@ -214,7 +214,8 @@ for line in sys.stdin:
     if (isinstance(content[-1], TextObservation) and content[-1].source == "agent") or isinstance(
         content[-1], ApiAction
     ):
-        user_end_message = random.choice(
+        terminal_message_rng = random.Random(str(id))
+        user_end_message = terminal_message_rng.choice(
             [
                 [
                     TextObservation(
@@ -244,7 +245,7 @@ for line in sys.stdin:
             ]
         )
         content.extend(user_end_message)
-        assistant_end_message = random.choice(
+        assistant_end_message = terminal_message_rng.choice(
             [
                 [
                     MessageAction(

--- a/datasets/agenttuning_kg/raw_to_standardized.py
+++ b/datasets/agenttuning_kg/raw_to_standardized.py
@@ -135,7 +135,8 @@ for line in sys.stdin:
     if not isinstance(content[-1], MessageAction) or "<solution>" not in content[-1].content:
         continue
 
-    user_end_message = random.choice(
+    terminal_message_rng = random.Random(str(raw_data["id"]))
+    user_end_message = terminal_message_rng.choice(
         [
             [
                 TextObservation(
@@ -165,7 +166,7 @@ for line in sys.stdin:
         ]
     )
     content.extend(user_end_message)
-    assistant_end_message = random.choice(
+    assistant_end_message = terminal_message_rng.choice(
         [
             [
                 MessageAction(

--- a/datasets/agenttuning_webshop/raw_to_standardized.py
+++ b/datasets/agenttuning_webshop/raw_to_standardized.py
@@ -125,7 +125,8 @@ for line in sys.stdin:
 
     # Handle finish actions for natural language based tasks
     if not isinstance(content[-1], MessageAction) or "<finish>" not in content[-1].content:
-        user_end_message = random.choice(
+        terminal_message_rng = random.Random(str(raw_data["id"]))
+        user_end_message = terminal_message_rng.choice(
             [
                 [
                     TextObservation(
@@ -155,7 +156,7 @@ for line in sys.stdin:
             ]
         )
         content.extend(user_end_message)
-        assistant_end_message = random.choice(
+        assistant_end_message = terminal_message_rng.choice(
             [
                 [
                     MessageAction(

--- a/datasets/code_feedback/raw_to_standardized.py
+++ b/datasets/code_feedback/raw_to_standardized.py
@@ -56,7 +56,8 @@ for line in sys.stdin:
         and content[-1].source == "assistant"
         or isinstance(content[-1], CodeAction)
     ):
-        user_end_message = random.choice(
+        terminal_message_rng = random.Random(str(raw_data["id"]))
+        user_end_message = terminal_message_rng.choice(
             [
                 [
                     TextObservation(
@@ -86,7 +87,7 @@ for line in sys.stdin:
             ]
         )
         content.extend(user_end_message)
-        assistant_end_message = random.choice(
+        assistant_end_message = terminal_message_rng.choice(
             [
                 [
                     MessageAction(

--- a/datasets/codeactinstruct/raw_to_standardized.py
+++ b/datasets/codeactinstruct/raw_to_standardized.py
@@ -115,7 +115,8 @@ for line in sys.stdin:
     if (isinstance(content[-1], TextObservation) and content[-1].source == "agent") or isinstance(
         content[-1], CodeAction
     ):
-        user_end_message = random.choice(
+        terminal_message_rng = random.Random(str(raw_data["id"]))
+        user_end_message = terminal_message_rng.choice(
             [
                 [
                     TextObservation(
@@ -145,7 +146,7 @@ for line in sys.stdin:
             ]
         )
         content.extend(user_end_message)
-        assistant_end_message = random.choice(
+        assistant_end_message = terminal_message_rng.choice(
             [
                 [
                     MessageAction(

--- a/datasets/coderforge_preview/raw_to_standardized.py
+++ b/datasets/coderforge_preview/raw_to_standardized.py
@@ -84,7 +84,8 @@ def process_data(data):
         else:
             assert False
     if not isinstance(content[-1], MessageAction) or "<finish>" not in content[-1].content:
-        user_end_message = random.choice(
+        terminal_message_rng = random.Random(str(id))
+        user_end_message = terminal_message_rng.choice(
             [
                 [
                     TextObservation(
@@ -114,7 +115,7 @@ def process_data(data):
             ]
         )
         content.extend(user_end_message)
-        assistant_end_message = random.choice(
+        assistant_end_message = terminal_message_rng.choice(
             [
                 [
                     MessageAction(

--- a/datasets/mind2web/raw_to_standardized.py
+++ b/datasets/mind2web/raw_to_standardized.py
@@ -326,7 +326,8 @@ if __name__ == "__main__":
             content.extend(convert_step(action, info_mapping, data.annotation_id))
 
         if isinstance(content[-1], ApiAction):
-            user_end_message = random.choice(
+            terminal_message_rng = random.Random(str(data.annotation_id))
+            user_end_message = terminal_message_rng.choice(
                 [
                     [
                         TextObservation(
@@ -356,7 +357,7 @@ if __name__ == "__main__":
                 ]
             )
             content.extend(user_end_message)
-            assistant_end_message = random.choice(
+            assistant_end_message = terminal_message_rng.choice(
                 [
                     [
                         MessageAction(

--- a/datasets/mini-coder/raw_to_standardized.py
+++ b/datasets/mini-coder/raw_to_standardized.py
@@ -149,7 +149,8 @@ def process_data(data):
         print(f"not COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT: {content[-1]}", file=sys.stderr)
         return None
     # Add success message from user
-    user_end_message = random.choice(
+    terminal_message_rng = random.Random(str(data.id))
+    user_end_message = terminal_message_rng.choice(
         [
             [
                 TextObservation(
@@ -181,7 +182,7 @@ def process_data(data):
     content.extend(user_end_message)
 
     # Add assistant end message
-    assistant_end_message = random.choice(
+    assistant_end_message = terminal_message_rng.choice(
         [
             [
                 MessageAction(

--- a/datasets/nebius_SWE-agent-trajectories/raw_to_standardized.py
+++ b/datasets/nebius_SWE-agent-trajectories/raw_to_standardized.py
@@ -93,7 +93,8 @@ def process_data(data):
 
     # Handle finish action
     if isinstance(content[-1], ApiAction) or isinstance(content[-1], CodeAction):
-        user_end_message = random.choice(
+        terminal_message_rng = random.Random(str(data.instance_id))
+        user_end_message = terminal_message_rng.choice(
             [
                 [
                     TextObservation(
@@ -123,7 +124,7 @@ def process_data(data):
             ]
         )
         content.extend(user_end_message)
-        assistant_end_message = random.choice(
+        assistant_end_message = terminal_message_rng.choice(
             [
                 [
                     MessageAction(

--- a/datasets/openhands/raw_to_standardized.py
+++ b/datasets/openhands/raw_to_standardized.py
@@ -453,7 +453,8 @@ def process_data(data, keep_all=False):
     if not isinstance(content[0], Observation):
         return None
     # Handle Finish Message
-    user_end_message = random.choice(
+    terminal_message_rng = random.Random(str(data.id))
+    user_end_message = terminal_message_rng.choice(
         [
             "Congratulations! You have successfully solved the task.",
             "Your solution has been verified as correct. ",
@@ -462,7 +463,7 @@ def process_data(data, keep_all=False):
             "Task completed successfully.",
         ]
     )
-    assistant_end_message = random.choice(
+    assistant_end_message = terminal_message_rng.choice(
         [
             "<finish> I have successfully completed the task. </finish>",
             "<finish> I did it! The task is now complete. </finish>",

--- a/datasets/orca_agentinstruct/raw_to_standardized.py
+++ b/datasets/orca_agentinstruct/raw_to_standardized.py
@@ -73,7 +73,8 @@ for line in sys.stdin:
         and content[-1].source == "assistant"
         or isinstance(content[-1], CodeAction)
     ):
-        user_end_message = random.choice(
+        terminal_message_rng = random.Random(str(raw_data["id"]))
+        user_end_message = terminal_message_rng.choice(
             [
                 [
                     TextObservation(
@@ -103,7 +104,7 @@ for line in sys.stdin:
             ]
         )
         content.extend(user_end_message)
-        assistant_end_message = random.choice(
+        assistant_end_message = terminal_message_rng.choice(
             [
                 [
                     MessageAction(

--- a/datasets/swe-gym_openhands_sampled_trajectories/raw_to_standardized.py
+++ b/datasets/swe-gym_openhands_sampled_trajectories/raw_to_standardized.py
@@ -84,7 +84,8 @@ def process_data(data):
         else:
             assert False
     if not isinstance(content[-1], MessageAction) or "<finish>" not in content[-1].content:
-        user_end_message = random.choice(
+        terminal_message_rng = random.Random(str(id))
+        user_end_message = terminal_message_rng.choice(
             [
                 [
                     TextObservation(
@@ -114,7 +115,7 @@ def process_data(data):
             ]
         )
         content.extend(user_end_message)
-        assistant_end_message = random.choice(
+        assistant_end_message = terminal_message_rng.choice(
             [
                 [
                     MessageAction(

--- a/datasets/swe-smith/raw_to_standardized.py
+++ b/datasets/swe-smith/raw_to_standardized.py
@@ -105,7 +105,8 @@ def process_data(data):
     # Only keep successful trajectories
     if not isinstance(content[-1], ApiAction) or content[-1].function != "submit":
         return None
-    user_end_message = random.choice(
+    terminal_message_rng = random.Random(str(data.id))
+    user_end_message = terminal_message_rng.choice(
         [
             [
                 TextObservation(
@@ -135,7 +136,7 @@ def process_data(data):
         ]
     )
     content.extend(user_end_message)
-    assistant_end_message = random.choice(
+    assistant_end_message = terminal_message_rng.choice(
         [
             [
                 MessageAction(

--- a/tests/test_deterministic_terminal_messages.py
+++ b/tests/test_deterministic_terminal_messages.py
@@ -1,0 +1,43 @@
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_dataset_converters_do_not_use_unseeded_random_choice():
+    offenders = []
+    for converter_path in sorted((REPO_ROOT / "datasets").glob("*/raw_to_standardized.py")):
+        tree = ast.parse(converter_path.read_text(), filename=str(converter_path))
+        random_module_names = {"random"}
+        random_choice_names = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "random":
+                        random_module_names.add(alias.asname or alias.name)
+            elif isinstance(node, ast.ImportFrom) and node.module == "random":
+                for alias in node.names:
+                    if alias.name == "choice":
+                        random_choice_names.add(alias.asname or alias.name)
+                    elif alias.name == "*":
+                        random_choice_names.add("choice")
+
+        for node in ast.walk(tree):
+            uses_random_choice = (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "choice"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in random_module_names
+            )
+            uses_imported_choice = (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in random_choice_names
+            )
+            if uses_random_choice or uses_imported_choice:
+                offenders.append(f"{converter_path.relative_to(REPO_ROOT)}:{node.lineno}")
+
+    assert not offenders, "Use a per-trajectory seeded RNG instead of random.choice: " + ", ".join(
+        offenders
+    )


### PR DESCRIPTION
## Summary
- Seed terminal/success message selection in affected `raw_to_standardized.py` converters from a stable per-trajectory ID.
- Replace unseeded `random.choice(...)` calls for converter success messages with per-trajectory seeded RNG choices.
- Add a regression test that prevents dataset converters from reintroducing unseeded `random.choice` calls.

Fixes #238.

## Tests
- `python -m ruff check datasets/openhands/raw_to_standardized.py datasets/agenttuning_webshop/raw_to_standardized.py datasets/code_feedback/raw_to_standardized.py datasets/coderforge_preview/raw_to_standardized.py datasets/orca_agentinstruct/raw_to_standardized.py datasets/mini-coder/raw_to_standardized.py datasets/agenttuning_alfworld/raw_to_standardized.py datasets/mind2web/raw_to_standardized.py datasets/agenttuning_kg/raw_to_standardized.py datasets/codeactinstruct/raw_to_standardized.py datasets/swe-gym_openhands_sampled_trajectories/raw_to_standardized.py datasets/nebius_SWE-agent-trajectories/raw_to_standardized.py datasets/swe-smith/raw_to_standardized.py tests/test_deterministic_terminal_messages.py`
- `python -m pytest tests/test_deterministic_terminal_messages.py tests/test_dataset_structure.py -q`
- `python -m pytest tests/test_standardized_schemas.py tests/test_deterministic_terminal_messages.py -q`
- `python -m pytest tests/test_raw_schemas.py -q`
- `python -m pytest tests/test_std_to_sft_conversion.py -q`
- `PATH=$HOME/.local/bin:$PATH python -m pytest tests/test_pre_commit.py -q`
- `PATH=$HOME/.local/bin:$PATH python -m pytest tests/ -q` (447 passed, 14 skipped, 4 warnings)
- Representative reproducibility smoke test: converted `datasets/agenttuning_alfworld/sample_raw.json` twice and compared identical outputs with `cmp`.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b846e5cc-7a9e-4723-a9c4-789bb9c82ad0)