### PR TITLE
Add PR artifacts cleanup workflow

### DIFF
--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -75,7 +75,7 @@ jobs:
               'The `.pr/` directory has been automatically removed.',
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
@@ -138,7 +138,7 @@ jobs:
               '> For fork PRs: Manual removal is required before merging.',
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -2,7 +2,6 @@
 name: PR Artifacts
 
 on:
-  workflow_dispatch: # Manual trigger for testing
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
@@ -23,12 +22,15 @@ jobs:
     steps:
       - name: Check if fork PR
         id: check-fork
+        env:
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
-            echo "is_fork=true" >> $GITHUB_OUTPUT
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Fork PR detected - skipping auto-cleanup (manual removal required)"
           else
-            echo "is_fork=false" >> $GITHUB_OUTPUT
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
           fi
 
       # Prefer the same bot PAT used by OpenHands/software-agent-sdk so the
@@ -53,10 +55,10 @@ jobs:
               echo "::error::Failed to push cleanup commit. Check branch protection rules."
               exit 1
             }
-            echo "removed=true" >> $GITHUB_OUTPUT
+            echo "removed=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Removed .pr/ directory"
           else
-            echo "removed=false" >> $GITHUB_OUTPUT
+            echo "removed=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No .pr/ directory to remove"
           fi
 
@@ -84,6 +86,13 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
                 body: body,
               });
             }

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -100,6 +100,9 @@ jobs:
 
   # Warn if .pr/ directory exists. It will be auto-removed on approval.
   check-pr-artifacts:
+    concurrency:
+      group: check-pr-artifacts-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -68,11 +68,12 @@ jobs:
         with:
           script: |
             const marker = '<!-- pr-artifacts-cleaned -->';
-            const body = `${marker}
-            **PR Artifacts Cleaned Up**
-
-            The \`.pr/\` directory has been automatically removed.
-            `;
+            const body = [
+              marker,
+              '**PR Artifacts Cleaned Up**',
+              '',
+              'The `.pr/` directory has been automatically removed.',
+            ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -125,13 +126,14 @@ jobs:
           script: |
             const marker = '<!-- pr-artifacts-notice -->';
             const exists = process.env.PR_ARTIFACTS_EXIST === 'true';
-            const body = `${marker}
-            **PR Artifacts Notice**
-
-            This PR contains a \`.pr/\` directory with PR-specific documents. This directory will be **automatically removed** when the PR is approved.
-
-            > For fork PRs: Manual removal is required before merging.
-            `;
+            const body = [
+              marker,
+              '**PR Artifacts Notice**',
+              '',
+              'This PR contains a `.pr/` directory with PR-specific documents. This directory will be **automatically removed** when the PR is approved.',
+              '',
+              '> For fork PRs: Manual removal is required before merging.',
+            ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const marker = '<!-- pr-artifacts-notice -->';
+            const marker = '<!-- pr-artifacts-cleaned -->';
             const body = `${marker}
             **PR Artifacts Cleaned Up**
 

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -1,0 +1,139 @@
+---
+name: PR Artifacts
+
+on:
+  workflow_dispatch: # Manual trigger for testing
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  # Auto-remove .pr/ directory when a reviewer approves.
+  cleanup-on-approval:
+    concurrency:
+      group: cleanup-pr-artifacts-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check if fork PR
+        id: check-fork
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+            echo "::notice::Fork PR detected - skipping auto-cleanup (manual removal required)"
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Prefer the same bot PAT used by OpenHands/software-agent-sdk so the
+      # cleanup push triggers required CI. Fall back to GITHUB_TOKEN when this
+      # repository has not configured the PAT secret.
+      - uses: actions/checkout@v6
+        if: steps.check-fork.outputs.is_fork == 'false'
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || github.token }}
+
+      - name: Remove .pr/ directory
+        id: remove
+        if: steps.check-fork.outputs.is_fork == 'false'
+        run: |
+          if [ -d ".pr" ]; then
+            git config user.name "allhands-bot"
+            git config user.email "allhands-bot@users.noreply.github.com"
+            git rm -rf .pr/
+            git commit -m "chore: Remove PR-only artifacts [automated]"
+            git push || {
+              echo "::error::Failed to push cleanup commit. Check branch protection rules."
+              exit 1
+            }
+            echo "removed=true" >> $GITHUB_OUTPUT
+            echo "::notice::Removed .pr/ directory"
+          else
+            echo "removed=false" >> $GITHUB_OUTPUT
+            echo "::notice::No .pr/ directory to remove"
+          fi
+
+      - name: Update PR comment after cleanup
+        if: steps.check-fork.outputs.is_fork == 'false' && steps.remove.outputs.removed == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- pr-artifacts-notice -->';
+            const body = `${marker}
+            **PR Artifacts Cleaned Up**
+
+            The \`.pr/\` directory has been automatically removed.
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            }
+
+  # Warn if .pr/ directory exists. It will be auto-removed on approval.
+  check-pr-artifacts:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check for .pr/ directory
+        id: check
+        run: |
+          if [ -d ".pr" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "::warning::.pr/ directory exists and will be automatically removed when the PR is approved. For fork PRs, manual removal is required before merging."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post or update PR comment
+        if: steps.check.outputs.exists == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- pr-artifacts-notice -->';
+            const body = `${marker}
+            **PR Artifacts Notice**
+
+            This PR contains a \`.pr/\` directory with PR-specific documents. This directory will be **automatically removed** when the PR is approved.
+
+            > For fork PRs: Manual removal is required before merging.
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (!existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -111,18 +111,20 @@ jobs:
         id: check
         run: |
           if [ -d ".pr" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "::warning::.pr/ directory exists and will be automatically removed when the PR is approved. For fork PRs, manual removal is required before merging."
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Post or update PR comment
-        if: steps.check.outputs.exists == 'true'
+      - name: Sync PR artifacts comment
         uses: actions/github-script@v9
+        env:
+          PR_ARTIFACTS_EXIST: ${{ steps.check.outputs.exists }}
         with:
           script: |
             const marker = '<!-- pr-artifacts-notice -->';
+            const exists = process.env.PR_ARTIFACTS_EXIST === 'true';
             const body = `${marker}
             **PR Artifacts Notice**
 
@@ -138,11 +140,24 @@ jobs:
             });
 
             const existing = comments.find(c => c.body.includes(marker));
-            if (!existing) {
+            if (exists && existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else if (exists) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: body,
+              });
+            } else if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
               });
             }


### PR DESCRIPTION
## Summary
- add the PR Artifacts workflow adapted from OpenHands/software-agent-sdk
- warn when a PR includes `.pr/` artifacts
- remove `.pr/` automatically on approval for same-repository PRs

## Validation
- `uv run --no-project --with pre-commit pre-commit run --files .github/workflows/pr-artifacts.yml`

Note: This PR was prepared by an AI agent.