### PR TITLE
Support SWE-chat dataset conversion

### DIFF
--- a/datasets/SALT-NLP_SWE-chat/README.md
+++ b/datasets/SALT-NLP_SWE-chat/README.md
@@ -37,7 +37,8 @@ export HF_TOKEN=your_huggingface_token_with_swe_chat_access
 
 python datasets/$MY_DATASET/extract_raw.py | head -3 | python scripts/jsonl_to_json.py > datasets/$MY_DATASET/sample_raw.json
 cat datasets/$MY_DATASET/sample_raw.json | python scripts/json_to_jsonl.py | python datasets/$MY_DATASET/raw_to_standardized.py | python scripts/jsonl_to_json.py > datasets/$MY_DATASET/sample_std.json
-cat datasets/$MY_DATASET/sample_std.json | python scripts/json_to_jsonl.py | python agents/openhands/std_to_sft.py --is_web=no --api_env=execute_bash | python scripts/jsonl_to_json.py > datasets/$MY_DATASET/sample_sft.json
+mkdir -p datasets/$MY_DATASET/sample_sft
+cat datasets/$MY_DATASET/sample_std.json | python scripts/json_to_jsonl.py | python agents/openhands_v0/std_to_sft.py --is_web=no --api_env=execute_bash | python scripts/jsonl_to_json.py > datasets/$MY_DATASET/sample_sft/openhands_v0.json
 ```
 
 For very large sessions during local experimentation, set `SWE_CHAT_MAX_TURNS_PER_SESSION` to cap the number of turns emitted per session. Do not use that cap for full reproducible extraction.

--- a/datasets/SALT-NLP_SWE-chat/raw_to_standardized.py
+++ b/datasets/SALT-NLP_SWE-chat/raw_to_standardized.py
@@ -1,7 +1,7 @@
 import json
 import re
 import sys
-from typing import Any
+from typing import Any, TypeVar
 
 from schema_raw import ConversationTurn, SchemaRaw
 
@@ -17,6 +17,68 @@ READ_TOOL_NAMES = {"read", "read_file"}
 WRITE_TOOL_NAMES = {"write", "write_file"}
 EDIT_TOOL_NAMES = {"edit", "edit_file"}
 THINK_TOOL_NAMES = {"think", "thinking"}
+ToolEvent = TypeVar("ToolEvent", CodeAction, ApiAction, TextObservation)
+
+
+def ordered_turns(data: SchemaRaw) -> list[ConversationTurn]:
+    return sorted(
+        data.turns,
+        key=lambda item: item.turn_number if item.turn_number is not None else float("inf"),
+    )
+
+
+def turn_type(turn: ConversationTurn) -> str:
+    return (turn.turn_type or "").lower()
+
+
+def role(turn: ConversationTurn) -> str:
+    return turn.role.lower()
+
+
+def is_user_prompt_turn(turn: ConversationTurn) -> bool:
+    return turn_type(turn) == "user_prompt" or (role(turn) == "user" and turn.is_conversational)
+
+
+def is_tool_use_turn(turn: ConversationTurn) -> bool:
+    return turn_type(turn) == "tool_use" or role(turn) == "tool_use"
+
+
+def is_tool_result_turn(turn: ConversationTurn) -> bool:
+    return turn_type(turn) == "tool_result" or role(turn) == "tool_result"
+
+
+def linkable_raw_tool_call_ids(turns: list[ConversationTurn]) -> set[str]:
+    action_indices: dict[str, list[int]] = {}
+    result_indices: dict[str, list[int]] = {}
+    first_user_index = next(
+        (index for index, turn in enumerate(turns) if is_user_prompt_turn(turn)), len(turns)
+    )
+    for index, turn in enumerate(turns[first_user_index:], start=first_user_index):
+        tool_call_id = optional_str(turn.tool_call_id)
+        if not tool_call_id:
+            continue
+        if is_tool_use_turn(turn):
+            action_indices.setdefault(tool_call_id, []).append(index)
+        elif is_tool_result_turn(turn):
+            result_indices.setdefault(tool_call_id, []).append(index)
+
+    linkable_ids = set()
+    for tool_call_id, actions in action_indices.items():
+        results = result_indices.get(tool_call_id, [])
+        if len(actions) == 1 and len(results) == 1 and actions[0] < results[0]:
+            linkable_ids.add(tool_call_id)
+    return linkable_ids
+
+
+def attach_raw_tool_call_id(
+    event: ToolEvent,
+    turn: ConversationTurn,
+    linkable_tool_call_ids: set[str],
+) -> ToolEvent:
+    tool_call_id = optional_str(turn.tool_call_id)
+    if tool_call_id in linkable_tool_call_ids:
+        event.tool_call_id = tool_call_id
+    return event
 
 
 def parse_json_maybe(value: Any) -> Any:
@@ -101,35 +163,51 @@ def as_str_replace_editor(
     return None
 
 
-def convert_tool_use(turn: ConversationTurn) -> CodeAction | ApiAction | None:
+def convert_tool_use(
+    turn: ConversationTurn, linkable_tool_call_ids: set[str]
+) -> CodeAction | ApiAction | None:
     name = (turn.tool_name or "generic_tool").strip() or "generic_tool"
     lower_name = name.lower()
     params = tool_input(turn)
 
     if lower_name in SHELL_TOOL_NAMES:
         command = params.get("command") or turn.command or turn.content or ""
-        return CodeAction(language="bash", content=str(command), description=name)
+        return attach_raw_tool_call_id(
+            CodeAction(language="bash", content=str(command), description=name),
+            turn,
+            linkable_tool_call_ids,
+        )
 
     if lower_name in THINK_TOOL_NAMES:
         thought = params.get("thought") or turn.content or ""
-        return ApiAction(function="think", kwargs={"thought": str(thought)}, description=name)
+        return attach_raw_tool_call_id(
+            ApiAction(function="think", kwargs={"thought": str(thought)}, description=name),
+            turn,
+            linkable_tool_call_ids,
+        )
 
     editor_action = as_str_replace_editor(turn, lower_name, params)
     if editor_action:
         editor_action.description = name
-        return editor_action
+        return attach_raw_tool_call_id(editor_action, turn, linkable_tool_call_ids)
 
     kwargs: dict[str, Any] = {"tool_name": name, "tool_input": params}
     if not params:
         kwargs["content"] = turn.content
-    return ApiAction(
-        function="generic_tool",
-        kwargs=kwargs,
-        description=clean_function_name(name),
+    return attach_raw_tool_call_id(
+        ApiAction(
+            function="generic_tool",
+            kwargs=kwargs,
+            description=clean_function_name(name),
+        ),
+        turn,
+        linkable_tool_call_ids,
     )
 
 
-def convert_turn(turn: ConversationTurn, seen_user_prompt: bool) -> list[Any]:
+def convert_turn(
+    turn: ConversationTurn, seen_user_prompt: bool, linkable_tool_call_ids: set[str]
+) -> list[Any]:
     content = turn.content or ""
     turn_type = (turn.turn_type or "").lower()
     role = turn.role.lower()
@@ -149,14 +227,15 @@ def convert_turn(turn: ConversationTurn, seen_user_prompt: bool) -> list[Any]:
             return []
         return [ApiAction(function="think", kwargs={"thought": content})]
 
-    if turn_type == "tool_use" or role == "tool_use":
-        action = convert_tool_use(turn)
+    if is_tool_use_turn(turn):
+        action = convert_tool_use(turn, linkable_tool_call_ids)
         return [action] if action else []
 
-    if turn_type == "tool_result" or role == "tool_result":
+    if is_tool_result_turn(turn):
         if not content:
             return []
-        return [TextObservation(content=content, source="environment")]
+        observation = TextObservation(content=content, source="environment")
+        return [attach_raw_tool_call_id(observation, turn, linkable_tool_call_ids)]
 
     if not seen_user_prompt:
         return []
@@ -213,12 +292,11 @@ def details_from_raw(data: SchemaRaw) -> dict[str, Any]:
 def process_data(data: SchemaRaw) -> Trajectory | None:
     content = []
     seen_user_prompt = False
+    turns = ordered_turns(data)
+    linkable_tool_call_ids = linkable_raw_tool_call_ids(turns)
 
-    for turn in sorted(
-        data.turns,
-        key=lambda item: item.turn_number if item.turn_number is not None else float("inf"),
-    ):
-        events = convert_turn(turn, seen_user_prompt)
+    for turn in turns:
+        events = convert_turn(turn, seen_user_prompt, linkable_tool_call_ids)
         has_user_prompt = any(
             isinstance(event, TextObservation) and event.source == "user" for event in events
         )

--- a/datasets/SALT-NLP_SWE-chat/sample_sft/openhands_v0.json
+++ b/datasets/SALT-NLP_SWE-chat/sample_sft/openhands_v0.json
@@ -74,7 +74,7 @@
       },
       {
         "role": "user",
-        "content": "That's the wrong parameter—the container animation is the slow part, not the individual card stagger."
+        "content": "That's the wrong parameter\u2014the container animation is the slow part, not the individual card stagger."
       },
       {
         "role": "assistant",

--- a/datasets/SALT-NLP_SWE-chat/sample_std.json
+++ b/datasets/SALT-NLP_SWE-chat/sample_std.json
@@ -15,7 +15,7 @@
         "description": null
       },
       {
-        "tool_call_id": "call_000001",
+        "tool_call_id": "toolu_sample_read_refs",
         "class_": "api_action",
         "function": "str_replace_editor",
         "kwargs": {
@@ -25,7 +25,7 @@
         "description": "Read"
       },
       {
-        "tool_call_id": "call_000001",
+        "tool_call_id": "toolu_sample_read_refs",
         "class_": "text_observation",
         "content": "@inproceedings{sample2026swechat, title={SWE-chat}, author={Baumann et al.}}",
         "name": null,
@@ -42,14 +42,14 @@
         "description": "Write"
       },
       {
-        "tool_call_id": "call_000002",
+        "tool_call_id": "toolu_sample_pdflatex",
         "class_": "code_action",
         "language": "bash",
         "content": "pdflatex SWE-chat.tex",
         "description": "Bash"
       },
       {
-        "tool_call_id": "call_000002",
+        "tool_call_id": "toolu_sample_pdflatex",
         "class_": "text_observation",
         "content": "Output written on SWE-chat.pdf (1 page).",
         "name": null,
@@ -67,14 +67,14 @@
         "source": "user"
       },
       {
-        "tool_call_id": "call_000003",
+        "tool_call_id": "toolu_sample_git",
         "class_": "code_action",
         "language": "bash",
         "content": "git add SWE-chat.tex && git commit -m 'Add SWE-chat paper' && git push",
         "description": "Bash"
       },
       {
-        "tool_call_id": "call_000003",
+        "tool_call_id": "toolu_sample_git",
         "class_": "text_observation",
         "content": "[main 1234567] Add SWE-chat paper\n 1 file changed, 5 insertions(+)",
         "name": null,
@@ -121,7 +121,7 @@
         "description": null
       },
       {
-        "tool_call_id": "call_000001",
+        "tool_call_id": "toolu_sample_edit_animation",
         "class_": "api_action",
         "function": "str_replace_editor",
         "kwargs": {
@@ -133,7 +133,7 @@
         "description": "Edit"
       },
       {
-        "tool_call_id": "call_000001",
+        "tool_call_id": "toolu_sample_edit_animation",
         "class_": "text_observation",
         "content": "Updated HistoryListView.swift",
         "name": null,
@@ -141,7 +141,7 @@
       },
       {
         "class_": "text_observation",
-        "content": "That's the wrong parameter—the container animation is the slow part, not the individual card stagger.",
+        "content": "That's the wrong parameter\u2014the container animation is the slow part, not the individual card stagger.",
         "name": null,
         "source": "user"
       },
@@ -189,7 +189,7 @@
         "description": null
       },
       {
-        "tool_call_id": "call_000001",
+        "tool_call_id": "toolu_sample_read_remote",
         "class_": "api_action",
         "function": "str_replace_editor",
         "kwargs": {
@@ -199,7 +199,7 @@
         "description": "read_file"
       },
       {
-        "tool_call_id": "call_000001",
+        "tool_call_id": "toolu_sample_read_remote",
         "class_": "text_observation",
         "content": "DEFAULT_JOB_NAME = f\"remote_{arg_hash}\"",
         "name": null,

--- a/datasets/SALT-NLP_SWE-chat/schema_raw.py
+++ b/datasets/SALT-NLP_SWE-chat/schema_raw.py
@@ -60,5 +60,5 @@ class SchemaRaw(BaseModel):
     prompt_count: int | None = None
     agent_percentage: float | None = None
     user_persona: str | None = None
-    session_success: str | None = None
+    session_success: int | float | str | None = None
     turns: list[ConversationTurn]

--- a/tests/test_swe_chat_conversion.py
+++ b/tests/test_swe_chat_conversion.py
@@ -102,6 +102,62 @@ def test_swe_chat_tool_rows_convert_to_adp_actions():
     assert "content" not in trajectory.content[5].kwargs
 
 
+def test_swe_chat_preserves_non_adjacent_raw_tool_call_ids():
+    converter = load_converter_module()
+    raw = converter.SchemaRaw(
+        session_id="tool-id-session",
+        repo_id="owner/repo",
+        turns=[
+            {
+                "turn_number": 0,
+                "role": "user",
+                "turn_type": "user_prompt",
+                "is_conversational": True,
+                "content": "Inspect the code and run tests.",
+            },
+            {
+                "turn_number": 1,
+                "role": "tool_use",
+                "turn_type": "tool_use",
+                "tool_name": "Read",
+                "tool_call_id": "source-call-read",
+                "tool_input_json": '{"file_path": "/workspace/app.py"}',
+            },
+            {
+                "turn_number": 2,
+                "role": "tool_use",
+                "turn_type": "tool_use",
+                "tool_name": "Bash",
+                "tool_call_id": "source-call-test",
+                "tool_input_json": '{"command": "pytest -q"}',
+            },
+            {
+                "turn_number": 3,
+                "role": "tool_result",
+                "turn_type": "tool_result",
+                "tool_call_id": "source-call-read",
+                "content": "print('hello')",
+            },
+            {
+                "turn_number": 4,
+                "role": "tool_result",
+                "turn_type": "tool_result",
+                "tool_call_id": "source-call-test",
+                "content": "1 passed",
+            },
+        ],
+    )
+
+    trajectory = converter.process_data(raw)
+
+    assert [event.tool_call_id for event in trajectory.content[1:5]] == [
+        "source-call-read",
+        "source-call-test",
+        "source-call-read",
+        "source-call-test",
+    ]
+
+
 def test_swe_chat_metadata_preserves_native_numeric_types():
     converter = load_converter_module()
     raw = converter.SchemaRaw(
@@ -111,7 +167,7 @@ def test_swe_chat_metadata_preserves_native_numeric_types():
         turn_count=7,
         prompt_count=2,
         agent_percentage=87.5,
-        session_success="100",
+        session_success=100,
         turns=[
             {
                 "turn_number": 0,


### PR DESCRIPTION
## Summary

Fixes #249.

Adds/updates SWE-chat dataset support by preserving source `tool_call_id` values when SWE-chat provides matched tool-use/tool-result pairs, allowing numeric `session_success` metadata, regenerating the standardized and OpenHands v0 SFT samples, and correcting the README sample-generation command.

## Dataset source

- Source: https://huggingface.co/datasets/SALT-NLP/SWE-chat
- License: ODC-BY (`odc-by` on the Hugging Face dataset card)
- Split/config used: `train` / `conversations`
- Size noted in dataset README: 2,692,480 conversation rows, 5,851 sessions, and 5,851 raw transcript files according to the Hugging Face dataset card

## Files changed

- `datasets/SALT-NLP_SWE-chat/raw_to_standardized.py`
- `datasets/SALT-NLP_SWE-chat/schema_raw.py`
- `datasets/SALT-NLP_SWE-chat/sample_std.json`
- `datasets/SALT-NLP_SWE-chat/sample_sft/openhands_v0.json`
- `datasets/SALT-NLP_SWE-chat/README.md`
- `tests/test_swe_chat_conversion.py`

## Schema mapping summary

- User prompt rows become `TextObservation(source="user")`.
- Assistant response rows become `MessageAction`.
- Assistant thinking rows become the `think` API action.
- Shell tool rows become `CodeAction(language="bash")`.
- Read/write/edit tool rows become `str_replace_editor` API actions.
- Other tools become `generic_tool` API actions.
- Tool-result rows become `TextObservation(source="environment")`.
- Source `tool_call_id` values are preserved only when there is exactly one matching tool-use row and one later matching tool-result row, preventing invalid unmatched or duplicate ADP links.

## Design decisions

- **Ambiguity:** SWE-chat may include raw `tool_call_id` values while ADP requires every populated action ID to have exactly one matching later observation.
  - **Chosen approach:** Preserve raw IDs only for unique, ordered action/result pairs and let existing adjacent backfill handle rows without safe source IDs.
  - **Example:** A `Read` call with `tool_call_id="source-call-read"` and a later result with the same ID both keep `source-call-read`, even if another tool call appears between them.
  - **Alternatives rejected:** Always copying raw IDs can fail schema validation for incomplete tool calls; always generating IDs loses source traceability.
- **Ambiguity:** `session_success` metadata may be represented as either a string or a native number.
  - **Chosen approach:** Accept `int | float | str | None` in the raw schema and continue emitting numeric detail values in standardized output.
  - **Example:** `session_success=100` is accepted and standardized as JSON number `100`.
  - **Alternatives rejected:** Keeping a string-only schema rejects numeric Hugging Face rows; storing numeric-looking values as strings violates numeric-detail validation.
- **Ambiguity:** README sample generation referenced the old SFT path.
  - **Chosen approach:** Update it to generate `sample_sft/openhands_v0.json` via `agents/openhands_v0/std_to_sft.py`.
  - **Example:** The documented command now creates `datasets/$MY_DATASET/sample_sft/openhands_v0.json`.
  - **Alternatives rejected:** Leaving the stale `sample_sft.json` command conflicts with the repository's current dataset structure requirements.

## Tests run

- `python -m pytest tests/test_swe_chat_conversion.py -q`
- `python -m pytest tests/test_dataset_structure.py tests/test_raw_schemas.py tests/test_standardized_schemas.py tests/test_std_to_sft_conversion.py -q -k 'SALT or SWE_chat or swe_chat'`
- `python -m pytest tests/test_datasets_from_parameter.py tests/test_openhands_v0_sft_role_preservation.py tests/test_sft_quality_control.py -q`
- `python -m ruff check datasets/SALT-NLP_SWE-chat tests/test_swe_chat_conversion.py`
- `python -m ruff format --check datasets/SALT-NLP_SWE-chat tests/test_swe_chat_conversion.py`
- `PATH="$HOME/.local/bin:$PATH" python -m pytest tests/ -q` — 458 passed, 95 skipped

## Known limitations

- The full Hugging Face dataset is gated; `extract_raw.py` still requires a Hugging Face token with accepted SWE-chat access for full extraction.
- This PR was created by an AI agent (OpenHands) on behalf of the user.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bd494a2a-0bad-4148-94e4-c2f196193086)