### PR TITLE
Use native async condenser generation

### DIFF
--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 import tempfile
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
@@ -214,44 +214,6 @@ def make_trajectory_record_from_conversation(
     }
 
 
-def condensation_prompt_record_if_needed(
-    *,
-    events: list[SDKEvent],
-    condenser: LLMSummarizingCondenser,
-    agent_llm: LLM,
-    condenser_llm: PromptCapturingLLM,
-    trajectory_id: str,
-    source_trajectory_id: str | None = None,
-    source_row_id: str | None = None,
-    dataset_name: str | None,
-    max_tokens: int,
-    condensation_index: int,
-) -> tuple[Condensation, dict[str, Any]] | None:
-    view = View.from_events(events)
-    prompt_token_count = token_count(view, condenser.llm)
-    before_prompt_count = len(condenser_llm.captured_messages)
-    condensation_result = condenser.condense(view, agent_llm=agent_llm)
-    if not isinstance(condensation_result, Condensation):
-        return None
-
-    if len(condenser_llm.captured_messages) != before_prompt_count + 1:
-        raise RuntimeError("Condenser returned Condensation without calling its LLM")
-
-    prompt_record = make_condensation_prompt_record(
-        trajectory_id=trajectory_id,
-        source_trajectory_id=source_trajectory_id,
-        source_row_id=source_row_id,
-        dataset_name=dataset_name,
-        prompt_messages=condenser_llm.captured_messages[-1],
-        formatting_llm=agent_llm,
-        condensation=condensation_result,
-        condensation_index=condensation_index,
-        max_tokens=max_tokens,
-        prompt_token_count=prompt_token_count,
-    )
-    return condensation_result, prompt_record
-
-
 async def acondensation_prompt_record_if_needed(
     *,
     events: list[SDKEvent],
@@ -290,156 +252,6 @@ async def acondensation_prompt_record_if_needed(
     return condensation_result, prompt_record
 
 
-def append_standardized_events_with_condensation(
-    *,
-    conversation: Conversation,
-    trajectory: Trajectory,
-    dataset_name: str | None,
-    max_tokens: int,
-    model: str,
-    max_size: int,
-    keep_first: int,
-    start_index: int,
-    include_trajectories: bool,
-    output_trajectory_id: str | None = None,
-    source_row_id: str | None = None,
-) -> list[dict[str, Any]]:
-    metadata = load_dataset_metadata(dataset_name, required=True)
-    event_history: list[SDKEvent] = [
-        SystemPromptEvent(
-            system_prompt=TextContent(text=conversation.agent.static_system_message),
-            tools=list(conversation.agent.tools_map.values()),
-        )
-    ]
-    builder = TrackingSDKEventBuilder(conversation, metadata, event_history)
-    first_event = trajectory.content[0]
-    index = start_index
-    if isinstance(first_event, TextObservation) and first_event.source == "user":
-        builder.append(
-            MessageEvent(
-                source="user",
-                llm_message=Message(
-                    role="user",
-                    content=[TextContent(text=first_event.content)],
-                ),
-            )
-        )
-    else:
-        builder.append(
-            MessageEvent(
-                source="user",
-                llm_message=Message(
-                    role="user",
-                    content=[
-                        TextContent(text="Continue the task from the current workspace state.")
-                    ],
-                ),
-            )
-        )
-        index = 0
-    condenser_llm = PromptCapturingLLM(
-        usage_id="openhands-sdk-condensation-sft-condenser",
-        model=model,
-        api_key=SecretStr(os.getenv("LLM_API_KEY") or "not-used"),
-        base_url=os.getenv("LLM_BASE_URL"),
-    )
-    condenser = LLMSummarizingCondenser(
-        llm=condenser_llm,
-        max_size=max_size,
-        max_tokens=max_tokens,
-        keep_first=keep_first,
-    )
-    records: list[dict[str, Any]] = []
-    record_trajectory_id = output_trajectory_id or trajectory.id
-    segment_index = 1
-    condensation_index = 1
-    batch_number = 0
-    last_safe_events = list(event_history)
-
-    def update_last_safe_events() -> None:
-        nonlocal last_safe_events
-        if formatted_token_count(event_history, conversation.agent.llm) <= max_tokens:
-            last_safe_events = list(event_history)
-
-    def emit_condensation_boundary_if_needed() -> None:
-        nonlocal segment_index, condensation_index, last_safe_events
-        result = condensation_prompt_record_if_needed(
-            events=event_history,
-            condenser=condenser,
-            agent_llm=conversation.agent.llm,
-            condenser_llm=condenser_llm,
-            trajectory_id=record_trajectory_id,
-            source_trajectory_id=trajectory.id,
-            source_row_id=source_row_id,
-            dataset_name=dataset_name,
-            max_tokens=max_tokens,
-            condensation_index=condensation_index,
-        )
-        if result is None:
-            return
-        condensation, prompt_record = result
-        if include_trajectories:
-            records.append(
-                make_trajectory_record_from_conversation(
-                    conversation=conversation,
-                    trajectory_id=record_trajectory_id,
-                    source_trajectory_id=trajectory.id,
-                    source_row_id=source_row_id,
-                    dataset_name=dataset_name,
-                    segment_index=segment_index,
-                    events=last_safe_events,
-                )
-            )
-            segment_index += 1
-        records.append(prompt_record)
-        event_history.append(condensation)
-        conversation.state.events.append(condensation)
-        last_safe_events = list(event_history)
-        condensation_index += 1
-
-    while index < len(trajectory.content):
-        event = trajectory.content[index]
-        if isinstance(event, (ApiAction, CodeAction)):
-            emit_condensation_boundary_if_needed()
-            action_batch: list[ApiAction | CodeAction] = []
-            while index < len(trajectory.content) and isinstance(
-                trajectory.content[index], (ApiAction, CodeAction)
-            ):
-                action_batch.append(trajectory.content[index])
-                index += 1
-            batch_number += 1
-            builder.append_action_batch(action_batch, batch_number=batch_number)
-            update_last_safe_events()
-            continue
-
-        if isinstance(event, MessageAction):
-            emit_condensation_boundary_if_needed()
-            append_message_action(builder, event)
-            update_last_safe_events()
-        elif isinstance(event, (TextObservation, WebObservation, ImageObservation)):
-            builder.append_observation(event)
-            update_last_safe_events()
-        else:
-            raise ValueError(f"Unsupported event type: {type(event)}")
-        index += 1
-
-    emit_condensation_boundary_if_needed()
-    if include_trajectories or not records:
-        records.append(
-            make_trajectory_record_from_conversation(
-                conversation=conversation,
-                trajectory_id=record_trajectory_id,
-                source_trajectory_id=trajectory.id,
-                source_row_id=source_row_id,
-                dataset_name=dataset_name,
-                segment_index=segment_index,
-                events=last_safe_events,
-            )
-        )
-
-    return records
-
-
 async def append_standardized_events_with_condensation_async(
     *,
     conversation: Conversation,
@@ -454,6 +266,14 @@ async def append_standardized_events_with_condensation_async(
     output_trajectory_id: str | None = None,
     source_row_id: str | None = None,
 ) -> list[dict[str, Any]]:
+    """Replay trajectory events and emit trajectory plus condensation records.
+
+    ``start_index`` is respected only when the first trajectory event is a user
+    ``TextObservation`` that has already been emitted as the opening user
+    message. On the fallback path, where there is no leading user message to
+    consume, the index is intentionally reset to 0 so no trajectory content is
+    skipped.
+    """
     metadata = load_dataset_metadata(dataset_name, required=True)
     event_history: list[SDKEvent] = [
         SystemPromptEvent(
@@ -600,42 +420,17 @@ def process_row(
     max_size: int = DEFAULT_MAX_SIZE,
     keep_first: int = 2,
 ) -> list[dict[str, Any]]:
-    trajectory = load_trajectory(line)
-    output_trajectory_id = trajectory.id
-    source_row_id = None
-    if os.getenv("ADP_USE_SOURCE_ROW_HASH") == "1":
-        source_row_id = source_row_id_from_line(line, trajectory.id)
-        output_trajectory_id = source_row_id
-    dataset_name = dataset_name or os.getenv("MY_DATASET")
-    metadata = load_dataset_metadata(dataset_name, required=True)
-    register_metadata_tools(metadata)
-
-    llm = LLM(
-        usage_id="openhands-sdk-condensation-sft-converter",
-        model=model,
-        api_key=SecretStr(os.getenv("LLM_API_KEY") or "not-used"),
-        base_url=os.getenv("LLM_BASE_URL"),
+    return asyncio.run(
+        process_row_async(
+            line,
+            max_tokens=max_tokens,
+            model=model,
+            dataset_name=dataset_name,
+            include_trajectories=include_trajectories,
+            max_size=max_size,
+            keep_first=keep_first,
+        )
     )
-    agent = Agent(llm=llm, tools=sdk_tool_specs(trajectory, metadata))
-    with tempfile.TemporaryDirectory(prefix="openhands-sdk-condensation-sft-") as tmpdir:
-        conversation = Conversation(agent=agent, workspace=tmpdir, visualizer=None)
-        try:
-            conversation._ensure_agent_ready()
-            return append_standardized_events_with_condensation(
-                conversation=conversation,
-                trajectory=trajectory,
-                dataset_name=dataset_name,
-                max_tokens=max_tokens,
-                model=model,
-                max_size=max_size,
-                keep_first=keep_first,
-                start_index=1,
-                include_trajectories=include_trajectories,
-                output_trajectory_id=output_trajectory_id,
-                source_row_id=source_row_id,
-            )
-        finally:
-            conversation.close()
 
 
 async def process_row_async(
@@ -684,20 +479,6 @@ async def process_row_async(
             )
         finally:
             conversation.close()
-
-
-def iter_input_chunks(chunk_size: int) -> Iterator[list[str]]:
-    chunk: list[str] = []
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-        chunk.append(line)
-        if len(chunk) >= chunk_size:
-            yield chunk
-            chunk = []
-    if chunk:
-        yield chunk
 
 
 async def process_line(
@@ -761,9 +542,7 @@ async def process_stream(args: argparse.Namespace) -> None:
                 line = line.strip()
                 if line:
                     pending.add(
-                        asyncio.create_task(
-                            process_line(line, args=args, semaphore=semaphore)
-                        )
+                        asyncio.create_task(process_line(line, args=args, semaphore=semaphore))
                     )
                     break
             else:
@@ -772,9 +551,7 @@ async def process_stream(args: argparse.Namespace) -> None:
     try:
         schedule_available()
         while pending:
-            done, pending = await asyncio.wait(
-                pending, return_when=asyncio.FIRST_COMPLETED
-            )
+            done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             for task in done:
                 records = await task
                 for record in records:

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -91,6 +91,25 @@ class PromptCapturingLLM(LLM):
             **kwargs,
         )
 
+    async def acompletion(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        _return_metrics: bool = False,
+        add_security_risk_prediction: bool = False,
+        on_token: Any | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        self._captured_messages.append(messages)
+        return await super().acompletion(
+            messages=messages,
+            tools=tools,
+            _return_metrics=_return_metrics,
+            add_security_risk_prediction=add_security_risk_prediction,
+            on_token=on_token,
+            **kwargs,
+        )
+
 
 def format_messages(llm: LLM, messages: list[Message]) -> list[dict[str, Any]]:
     return normalize_message_content(llm.format_messages_for_llm(messages))
@@ -212,6 +231,44 @@ def condensation_prompt_record_if_needed(
     prompt_token_count = token_count(view, condenser.llm)
     before_prompt_count = len(condenser_llm.captured_messages)
     condensation_result = condenser.condense(view, agent_llm=agent_llm)
+    if not isinstance(condensation_result, Condensation):
+        return None
+
+    if len(condenser_llm.captured_messages) != before_prompt_count + 1:
+        raise RuntimeError("Condenser returned Condensation without calling its LLM")
+
+    prompt_record = make_condensation_prompt_record(
+        trajectory_id=trajectory_id,
+        source_trajectory_id=source_trajectory_id,
+        source_row_id=source_row_id,
+        dataset_name=dataset_name,
+        prompt_messages=condenser_llm.captured_messages[-1],
+        formatting_llm=agent_llm,
+        condensation=condensation_result,
+        condensation_index=condensation_index,
+        max_tokens=max_tokens,
+        prompt_token_count=prompt_token_count,
+    )
+    return condensation_result, prompt_record
+
+
+async def acondensation_prompt_record_if_needed(
+    *,
+    events: list[SDKEvent],
+    condenser: LLMSummarizingCondenser,
+    agent_llm: LLM,
+    condenser_llm: PromptCapturingLLM,
+    trajectory_id: str,
+    source_trajectory_id: str | None = None,
+    source_row_id: str | None = None,
+    dataset_name: str | None,
+    max_tokens: int,
+    condensation_index: int,
+) -> tuple[Condensation, dict[str, Any]] | None:
+    view = View.from_events(events)
+    prompt_token_count = token_count(view, condenser.llm)
+    before_prompt_count = len(condenser_llm.captured_messages)
+    condensation_result = await condenser.acondense(view, agent_llm=agent_llm)
     if not isinstance(condensation_result, Condensation):
         return None
 
@@ -383,6 +440,156 @@ def append_standardized_events_with_condensation(
     return records
 
 
+async def append_standardized_events_with_condensation_async(
+    *,
+    conversation: Conversation,
+    trajectory: Trajectory,
+    dataset_name: str | None,
+    max_tokens: int,
+    model: str,
+    max_size: int,
+    keep_first: int,
+    start_index: int,
+    include_trajectories: bool,
+    output_trajectory_id: str | None = None,
+    source_row_id: str | None = None,
+) -> list[dict[str, Any]]:
+    metadata = load_dataset_metadata(dataset_name, required=True)
+    event_history: list[SDKEvent] = [
+        SystemPromptEvent(
+            system_prompt=TextContent(text=conversation.agent.static_system_message),
+            tools=list(conversation.agent.tools_map.values()),
+        )
+    ]
+    builder = TrackingSDKEventBuilder(conversation, metadata, event_history)
+    first_event = trajectory.content[0]
+    index = start_index
+    if isinstance(first_event, TextObservation) and first_event.source == "user":
+        builder.append(
+            MessageEvent(
+                source="user",
+                llm_message=Message(
+                    role="user",
+                    content=[TextContent(text=first_event.content)],
+                ),
+            )
+        )
+    else:
+        builder.append(
+            MessageEvent(
+                source="user",
+                llm_message=Message(
+                    role="user",
+                    content=[
+                        TextContent(text="Continue the task from the current workspace state.")
+                    ],
+                ),
+            )
+        )
+        index = 0
+    condenser_llm = PromptCapturingLLM(
+        usage_id="openhands-sdk-condensation-sft-condenser",
+        model=model,
+        api_key=SecretStr(os.getenv("LLM_API_KEY") or "not-used"),
+        base_url=os.getenv("LLM_BASE_URL"),
+    )
+    condenser = LLMSummarizingCondenser(
+        llm=condenser_llm,
+        max_size=max_size,
+        max_tokens=max_tokens,
+        keep_first=keep_first,
+    )
+    records: list[dict[str, Any]] = []
+    record_trajectory_id = output_trajectory_id or trajectory.id
+    segment_index = 1
+    condensation_index = 1
+    batch_number = 0
+    last_safe_events = list(event_history)
+
+    def update_last_safe_events() -> None:
+        nonlocal last_safe_events
+        if formatted_token_count(event_history, conversation.agent.llm) <= max_tokens:
+            last_safe_events = list(event_history)
+
+    async def emit_condensation_boundary_if_needed() -> None:
+        nonlocal segment_index, condensation_index, last_safe_events
+        result = await acondensation_prompt_record_if_needed(
+            events=event_history,
+            condenser=condenser,
+            agent_llm=conversation.agent.llm,
+            condenser_llm=condenser_llm,
+            trajectory_id=record_trajectory_id,
+            source_trajectory_id=trajectory.id,
+            source_row_id=source_row_id,
+            dataset_name=dataset_name,
+            max_tokens=max_tokens,
+            condensation_index=condensation_index,
+        )
+        if result is None:
+            return
+        condensation, prompt_record = result
+        if include_trajectories:
+            records.append(
+                make_trajectory_record_from_conversation(
+                    conversation=conversation,
+                    trajectory_id=record_trajectory_id,
+                    source_trajectory_id=trajectory.id,
+                    source_row_id=source_row_id,
+                    dataset_name=dataset_name,
+                    segment_index=segment_index,
+                    events=last_safe_events,
+                )
+            )
+            segment_index += 1
+        records.append(prompt_record)
+        event_history.append(condensation)
+        conversation.state.events.append(condensation)
+        last_safe_events = list(event_history)
+        condensation_index += 1
+
+    while index < len(trajectory.content):
+        event = trajectory.content[index]
+        if isinstance(event, (ApiAction, CodeAction)):
+            await emit_condensation_boundary_if_needed()
+            action_batch: list[ApiAction | CodeAction] = []
+            while index < len(trajectory.content) and isinstance(
+                trajectory.content[index], (ApiAction, CodeAction)
+            ):
+                action_batch.append(trajectory.content[index])
+                index += 1
+            batch_number += 1
+            builder.append_action_batch(action_batch, batch_number=batch_number)
+            update_last_safe_events()
+            continue
+
+        if isinstance(event, MessageAction):
+            await emit_condensation_boundary_if_needed()
+            append_message_action(builder, event)
+            update_last_safe_events()
+        elif isinstance(event, (TextObservation, WebObservation, ImageObservation)):
+            builder.append_observation(event)
+            update_last_safe_events()
+        else:
+            raise ValueError(f"Unsupported event type: {type(event)}")
+        index += 1
+
+    await emit_condensation_boundary_if_needed()
+    if include_trajectories or not records:
+        records.append(
+            make_trajectory_record_from_conversation(
+                conversation=conversation,
+                trajectory_id=record_trajectory_id,
+                source_trajectory_id=trajectory.id,
+                source_row_id=source_row_id,
+                dataset_name=dataset_name,
+                segment_index=segment_index,
+                events=last_safe_events,
+            )
+        )
+
+    return records
+
+
 def process_row(
     line: str,
     *,
@@ -431,6 +638,54 @@ def process_row(
             conversation.close()
 
 
+async def process_row_async(
+    line: str,
+    *,
+    max_tokens: int,
+    model: str,
+    dataset_name: str | None = None,
+    include_trajectories: bool = True,
+    max_size: int = DEFAULT_MAX_SIZE,
+    keep_first: int = 2,
+) -> list[dict[str, Any]]:
+    trajectory = load_trajectory(line)
+    output_trajectory_id = trajectory.id
+    source_row_id = None
+    if os.getenv("ADP_USE_SOURCE_ROW_HASH") == "1":
+        source_row_id = source_row_id_from_line(line, trajectory.id)
+        output_trajectory_id = source_row_id
+    dataset_name = dataset_name or os.getenv("MY_DATASET")
+    metadata = load_dataset_metadata(dataset_name, required=True)
+    register_metadata_tools(metadata)
+
+    llm = LLM(
+        usage_id="openhands-sdk-condensation-sft-converter",
+        model=model,
+        api_key=SecretStr(os.getenv("LLM_API_KEY") or "not-used"),
+        base_url=os.getenv("LLM_BASE_URL"),
+    )
+    agent = Agent(llm=llm, tools=sdk_tool_specs(trajectory, metadata))
+    with tempfile.TemporaryDirectory(prefix="openhands-sdk-condensation-sft-") as tmpdir:
+        conversation = Conversation(agent=agent, workspace=tmpdir, visualizer=None)
+        try:
+            conversation._ensure_agent_ready()
+            return await append_standardized_events_with_condensation_async(
+                conversation=conversation,
+                trajectory=trajectory,
+                dataset_name=dataset_name,
+                max_tokens=max_tokens,
+                model=model,
+                max_size=max_size,
+                keep_first=keep_first,
+                start_index=1,
+                include_trajectories=include_trajectories,
+                output_trajectory_id=output_trajectory_id,
+                source_row_id=source_row_id,
+            )
+        finally:
+            conversation.close()
+
+
 def iter_input_chunks(chunk_size: int) -> Iterator[list[str]]:
     chunk: list[str] = []
     for line in sys.stdin:
@@ -453,8 +708,7 @@ async def process_line(
 ) -> list[dict[str, Any]]:
     try:
         async with semaphore:
-            return await asyncio.to_thread(
-                process_row,
+            return await process_row_async(
                 line,
                 max_tokens=args.max_tokens,
                 model=args.model,
@@ -489,23 +743,49 @@ async def process_stream(args: argparse.Namespace) -> None:
     from tqdm import tqdm
 
     semaphore = asyncio.Semaphore(args.concurrency)
+    max_in_flight = max(args.chunk_size, args.concurrency)
     progress = tqdm(
         desc="condensation_sft",
         unit="row",
         dynamic_ncols=True,
         disable=args.no_progress,
     )
+    pending: set[asyncio.Task[list[dict[str, Any]]]] = set()
+    input_exhausted = False
+    input_iter = iter(sys.stdin)
+
+    def schedule_available() -> None:
+        nonlocal input_exhausted
+        while len(pending) < max_in_flight and not input_exhausted:
+            for line in input_iter:
+                line = line.strip()
+                if line:
+                    pending.add(
+                        asyncio.create_task(
+                            process_line(line, args=args, semaphore=semaphore)
+                        )
+                    )
+                    break
+            else:
+                input_exhausted = True
+
     try:
-        for chunk in iter_input_chunks(args.chunk_size):
-            tasks = [
-                asyncio.create_task(process_line(line, args=args, semaphore=semaphore))
-                for line in chunk
-            ]
-            for task in asyncio.as_completed(tasks):
+        schedule_available()
+        while pending:
+            done, pending = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done:
                 records = await task
                 for record in records:
                     print(json.dumps(record, ensure_ascii=False), flush=True)
                 progress.update(1)
+            schedule_available()
+    except Exception:
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        raise
     finally:
         progress.close()
 
@@ -537,7 +817,7 @@ def main() -> None:
         "--chunk-size",
         type=int,
         default=100,
-        help="Number of input rows to schedule per async batch.",
+        help="Maximum number of input rows to keep scheduled at once.",
     )
     parser.add_argument(
         "--no-progress",

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -72,25 +72,6 @@ class PromptCapturingLLM(LLM):
     def captured_messages(self) -> list[list[Message]]:
         return self._captured_messages
 
-    def completion(
-        self,
-        messages: list[Message],
-        tools: Sequence[ToolDefinition] | None = None,
-        _return_metrics: bool = False,
-        add_security_risk_prediction: bool = False,
-        on_token: Any | None = None,
-        **kwargs: Any,
-    ) -> LLMResponse:
-        self._captured_messages.append(messages)
-        return super().completion(
-            messages=messages,
-            tools=tools,
-            _return_metrics=_return_metrics,
-            add_security_risk_prediction=add_security_risk_prediction,
-            on_token=on_token,
-            **kwargs,
-        )
-
     async def acompletion(
         self,
         messages: list[Message],

--- a/tests/test_openhands_sdk_sft_conversion.py
+++ b/tests/test_openhands_sdk_sft_conversion.py
@@ -101,16 +101,7 @@ def patch_condensation_llm(monkeypatch, summary="[ATIF condensation test summary
 
     from agents.openhands_sdk import condensation_sft
 
-    def fake_completion(
-        self,
-        messages,
-        tools=None,
-        _return_metrics=False,
-        add_security_risk_prediction=False,
-        on_token=None,
-        **kwargs,
-    ):
-        self._captured_messages.append(messages)
+    def fake_response(self):
         return LLMResponse(
             message=Message(role="assistant", content=[TextContent(text=summary)]),
             metrics=MetricsSnapshot(
@@ -147,17 +138,9 @@ def patch_condensation_llm(monkeypatch, summary="[ATIF condensation test summary
         on_token=None,
         **kwargs,
     ):
-        return fake_completion(
-            self,
-            messages,
-            tools=tools,
-            _return_metrics=_return_metrics,
-            add_security_risk_prediction=add_security_risk_prediction,
-            on_token=on_token,
-            **kwargs,
-        )
+        self._captured_messages.append(messages)
+        return fake_response(self)
 
-    monkeypatch.setattr(condensation_sft.PromptCapturingLLM, "completion", fake_completion)
     monkeypatch.setattr(condensation_sft.PromptCapturingLLM, "acompletion", fake_acompletion)
 
 

--- a/tests/test_openhands_sdk_sft_conversion.py
+++ b/tests/test_openhands_sdk_sft_conversion.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import re
@@ -137,7 +138,27 @@ def patch_condensation_llm(monkeypatch, summary="[ATIF condensation test summary
             ),
         )
 
+    async def fake_acompletion(
+        self,
+        messages,
+        tools=None,
+        _return_metrics=False,
+        add_security_risk_prediction=False,
+        on_token=None,
+        **kwargs,
+    ):
+        return fake_completion(
+            self,
+            messages,
+            tools=tools,
+            _return_metrics=_return_metrics,
+            add_security_risk_prediction=add_security_risk_prediction,
+            on_token=on_token,
+            **kwargs,
+        )
+
     monkeypatch.setattr(condensation_sft.PromptCapturingLLM, "completion", fake_completion)
+    monkeypatch.setattr(condensation_sft.PromptCapturingLLM, "acompletion", fake_acompletion)
 
 
 @pytest.mark.parametrize("dataset", sample_std_datasets())
@@ -358,6 +379,34 @@ def test_openhands_sdk_condensation_utility_emits_llm_summaries_after_trajectori
     assert prompt_records[0]["metadata"]["prompt_token_count_before_condensation"] > 2000
     assert prompt_records[0]["metadata"]["forgotten_event_count"] > 0
     assert prompt_records[0]["metadata"]["condensation_output"] == "llm"
+
+
+def test_openhands_sdk_condensation_utility_async_path_emits_llm_summaries(monkeypatch):
+    from agents.openhands_sdk import condensation_sft
+
+    patch_condensation_llm(monkeypatch, summary="[async condensation summary]")
+    dataset = "agenttuning_os"
+    source = json.loads((DATASET_PATH / dataset / "sample_std.json").read_text())[0]
+
+    records = asyncio.run(
+        condensation_sft.process_row_async(
+            json.dumps(source),
+            max_tokens=2000,
+            model="gpt-4o-mini",
+            dataset_name=dataset,
+        )
+    )
+
+    prompt_records = [
+        record
+        for record in records
+        if record["metadata"]["generation"] == "openhands_sdk_condensation_prompt"
+    ]
+    assert prompt_records
+    assert prompt_records[0]["messages"][-1] == {
+        "role": "assistant",
+        "content": "[async condensation summary]",
+    }
 
 
 def test_openhands_sdk_condensation_utility_rejects_non_llm_output_modes():


### PR DESCRIPTION
## Summary
- use the OpenHands SDK async condenser path and native async LLM completions for PR256 condenser generation
- keep the existing CLI and output format unchanged
- replace chunk-draining with a bounded refill loop so slow rows do not idle available concurrency

## Verification
- /home/gneubig/workspace/project/b0ec6769629643e9b4eb723ca0e440cf/agent-data-protocol/.venv/bin/python -m py_compile agents/openhands_sdk/condensation_sft.py
- .venv/bin/python -m pytest tests/test_openhands_sdk_sft_conversion.py -q
- async fake-LLM smoke for process_row_async
- CLI no-condensation JSONL smoke with --concurrency 2 --chunk-size 3

Closes #267

## Issue

Closes #270
