### PR TITLE
Add row timeout for condenser generation

### DIFF
--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -479,23 +479,21 @@ async def process_line(
     line: str,
     *,
     args: argparse.Namespace,
-    semaphore: asyncio.Semaphore,
     llm_semaphore: asyncio.Semaphore,
 ) -> list[dict[str, Any]]:
     try:
-        async with semaphore:
-            row_task = process_row_async(
-                line,
-                max_tokens=args.max_tokens,
-                model=args.model,
-                include_trajectories=args.include_trajectories == "yes",
-                max_size=args.max_size,
-                keep_first=args.keep_first,
-                llm_semaphore=llm_semaphore,
-            )
-            if args.row_timeout > 0:
-                return await asyncio.wait_for(row_task, timeout=args.row_timeout)
-            return await row_task
+        row_task = process_row_async(
+            line,
+            max_tokens=args.max_tokens,
+            model=args.model,
+            include_trajectories=args.include_trajectories == "yes",
+            max_size=args.max_size,
+            keep_first=args.keep_first,
+            llm_semaphore=llm_semaphore,
+        )
+        if args.row_timeout > 0:
+            return await asyncio.wait_for(row_task, timeout=args.row_timeout)
+        return await row_task
     except TimeoutError:
         row_id = None
         try:
@@ -541,9 +539,7 @@ async def process_line(
 async def process_stream(args: argparse.Namespace) -> None:
     from tqdm import tqdm
 
-    semaphore = asyncio.Semaphore(args.concurrency)
     llm_semaphore = asyncio.Semaphore(args.llm_concurrency)
-    max_in_flight = max(args.chunk_size, args.concurrency)
     progress = tqdm(
         desc="condensation_sft",
         unit="row",
@@ -556,7 +552,7 @@ async def process_stream(args: argparse.Namespace) -> None:
 
     def schedule_available() -> None:
         nonlocal input_exhausted
-        while len(pending) < max_in_flight and not input_exhausted:
+        while len(pending) < args.max_in_flight_rows and not input_exhausted:
             for line in input_iter:
                 line = line.strip()
                 if line:
@@ -565,7 +561,6 @@ async def process_stream(args: argparse.Namespace) -> None:
                             process_line(
                                 line,
                                 args=args,
-                                semaphore=semaphore,
                                 llm_semaphore=llm_semaphore,
                             )
                         )
@@ -611,15 +606,15 @@ def main() -> None:
         help="Whether to emit the original OpenHands SDK trajectory record before summaries.",
     )
     parser.add_argument(
-        "--concurrency",
-        type=int,
-        default=1,
-        help="Number of input trajectories to process concurrently.",
-    )
-    parser.add_argument(
         "--chunk-size",
         type=int,
-        default=100,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--max-in-flight-rows",
+        type=int,
+        default=int(os.getenv("ADP_CONDENSER_MAX_IN_FLIGHT_ROWS", "100")),
         help="Maximum number of input rows to keep scheduled at once.",
     )
     parser.add_argument(
@@ -628,7 +623,7 @@ def main() -> None:
         default=int(os.getenv("ADP_CONDENSER_LLM_CONCURRENCY", "0")),
         help=(
             "Maximum concurrent async condenser LLM requests. Defaults to "
-            "--concurrency when unset or 0."
+            "--max-in-flight-rows when unset or 0."
         ),
     )
     parser.add_argument(
@@ -651,14 +646,14 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
-    if args.concurrency < 1:
-        raise ValueError("--concurrency must be at least 1")
-    if args.chunk_size < 1:
-        raise ValueError("--chunk-size must be at least 1")
+    if args.chunk_size is not None:
+        args.max_in_flight_rows = args.chunk_size
+    if args.max_in_flight_rows < 1:
+        raise ValueError("--max-in-flight-rows must be at least 1")
     if args.llm_concurrency < 0:
         raise ValueError("--llm-concurrency must be non-negative")
     if args.llm_concurrency == 0:
-        args.llm_concurrency = args.concurrency
+        args.llm_concurrency = args.max_in_flight_rows
     if args.row_timeout < 0:
         raise ValueError("--row-timeout must be non-negative")
     try:

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -23,8 +23,12 @@ from openhands.sdk.event.condenser import Condensation
 from openhands.sdk.llm.llm_response import LLMResponse
 from openhands.sdk.tool import ToolDefinition
 from pydantic import PrivateAttr, SecretStr
-from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt
-from tenacity import wait_exponential_jitter
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 
 from agents.openhands_sdk.std_to_sft import (
     SDKEventBuilder,
@@ -694,8 +698,7 @@ def main() -> None:
         type=float,
         default=float(os.getenv("ADP_CONDENSER_ROW_TIMEOUT", "1800")),
         help=(
-            "Maximum seconds to spend on one input row before failing the run. "
-            "Set to 0 to disable."
+            "Maximum seconds to spend on one input row before failing the run. Set to 0 to disable."
         ),
     )
     parser.add_argument(

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -494,7 +494,7 @@ async def process_line(
         if args.row_timeout > 0:
             return await asyncio.wait_for(row_task, timeout=args.row_timeout)
         return await row_task
-    except TimeoutError:
+    except asyncio.TimeoutError:
         row_id = None
         try:
             row_id = json.loads(line).get("id")
@@ -658,7 +658,7 @@ def main() -> None:
         raise ValueError("--row-timeout must be non-negative")
     try:
         asyncio.run(process_stream(args))
-    except TimeoutError:
+    except asyncio.TimeoutError:
         sys.exit(124)
 
 

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -13,6 +13,14 @@ from typing import Any
 os.environ.setdefault("OPENHANDS_SUPPRESS_BANNER", "1")
 os.environ.setdefault("LOG_LEVEL", "ERROR")
 
+from litellm.exceptions import (
+    APIConnectionError,
+    BadGatewayError,
+    InternalServerError,
+    RateLimitError,
+    ServiceUnavailableError,
+    Timeout,
+)
 from openhands.sdk import LLM, Agent, Conversation, LLMConvertibleEvent, Message, TextContent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.context.condenser.utils import get_total_token_count
@@ -51,6 +59,16 @@ from scripts.atif_input import (
 )
 
 DEFAULT_MAX_SIZE = 1_000_000
+TRANSIENT_LLM_EXCEPTIONS = (
+    APIConnectionError,
+    BadGatewayError,
+    InternalServerError,
+    RateLimitError,
+    ServiceUnavailableError,
+    Timeout,
+    OSError,
+    asyncio.TimeoutError,
+)
 
 
 def source_row_id_from_line(line: str, trajectory_id: str) -> str:
@@ -129,7 +147,7 @@ class PromptCapturingLLM(LLM):
                     initial=self._llm_retry_min_wait,
                     max=self._llm_retry_max_wait,
                 ),
-                retry=retry_if_exception_type(Exception),
+                retry=retry_if_exception_type(TRANSIENT_LLM_EXCEPTIONS),
                 reraise=True,
             ):
                 with attempt:

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -470,7 +470,7 @@ async def process_line(
 ) -> list[dict[str, Any]]:
     try:
         async with semaphore:
-            return await process_row_async(
+            row_task = process_row_async(
                 line,
                 max_tokens=args.max_tokens,
                 model=args.model,
@@ -478,6 +478,28 @@ async def process_line(
                 max_size=args.max_size,
                 keep_first=args.keep_first,
             )
+            if args.row_timeout > 0:
+                return await asyncio.wait_for(row_task, timeout=args.row_timeout)
+            return await row_task
+    except TimeoutError:
+        row_id = None
+        try:
+            row_id = json.loads(line).get("id")
+        except Exception:
+            pass
+        print(
+            json.dumps(
+                {
+                    "id": row_id,
+                    "error_type": "TimeoutError",
+                    "error": f"row exceeded timeout={args.row_timeout}s",
+                },
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
+        raise
     except Exception as exc:
         if not args.continue_on_error:
             raise
@@ -587,12 +609,26 @@ def main() -> None:
         action="store_true",
         help="Log per-row conversion errors to stderr and continue processing remaining rows.",
     )
+    parser.add_argument(
+        "--row-timeout",
+        type=float,
+        default=float(os.getenv("ADP_CONDENSER_ROW_TIMEOUT", "1800")),
+        help=(
+            "Maximum seconds to spend on one input row before failing the run. "
+            "Set to 0 to disable."
+        ),
+    )
     args = parser.parse_args()
     if args.concurrency < 1:
         raise ValueError("--concurrency must be at least 1")
     if args.chunk_size < 1:
         raise ValueError("--chunk-size must be at least 1")
-    asyncio.run(process_stream(args))
+    if args.row_timeout < 0:
+        raise ValueError("--row-timeout must be non-negative")
+    try:
+        asyncio.run(process_stream(args))
+    except TimeoutError:
+        sys.exit(124)
 
 
 if __name__ == "__main__":

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -581,8 +581,6 @@ async def process_line(
         await asyncio.gather(row_task, return_exceptions=True)
         raise
     except asyncio.TimeoutError:
-        row_task.cancel()
-        await asyncio.gather(row_task, return_exceptions=True)
         log_error("TimeoutError", f"row exceeded timeout={args.row_timeout}s")
         if args.continue_on_error:
             return []

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -63,10 +63,13 @@ class PromptCapturingLLM(LLM):
     """LLM that records condenser prompts before delegating to LiteLLM."""
 
     _captured_messages: list[list[Message]] = PrivateAttr(default_factory=list)
+    _completion_semaphore: asyncio.Semaphore | None = PrivateAttr(default=None)
 
     def __init__(self, **data: Any) -> None:
+        completion_semaphore = data.pop("completion_semaphore", None)
         super().__init__(**data)
         self._captured_messages = []
+        self._completion_semaphore = completion_semaphore
 
     @property
     def captured_messages(self) -> list[list[Message]]:
@@ -81,15 +84,21 @@ class PromptCapturingLLM(LLM):
         on_token: Any | None = None,
         **kwargs: Any,
     ) -> LLMResponse:
-        self._captured_messages.append(messages)
-        return await super().acompletion(
-            messages=messages,
-            tools=tools,
-            _return_metrics=_return_metrics,
-            add_security_risk_prediction=add_security_risk_prediction,
-            on_token=on_token,
-            **kwargs,
-        )
+        async def run_completion() -> LLMResponse:
+            self._captured_messages.append(messages)
+            return await super(PromptCapturingLLM, self).acompletion(
+                messages=messages,
+                tools=tools,
+                _return_metrics=_return_metrics,
+                add_security_risk_prediction=add_security_risk_prediction,
+                on_token=on_token,
+                **kwargs,
+            )
+
+        if self._completion_semaphore is None:
+            return await run_completion()
+        async with self._completion_semaphore:
+            return await run_completion()
 
 
 def format_messages(llm: LLM, messages: list[Message]) -> list[dict[str, Any]]:
@@ -246,6 +255,7 @@ async def append_standardized_events_with_condensation_async(
     include_trajectories: bool,
     output_trajectory_id: str | None = None,
     source_row_id: str | None = None,
+    llm_semaphore: asyncio.Semaphore | None = None,
 ) -> list[dict[str, Any]]:
     """Replay trajectory events and emit trajectory plus condensation records.
 
@@ -293,6 +303,7 @@ async def append_standardized_events_with_condensation_async(
         model=model,
         api_key=SecretStr(os.getenv("LLM_API_KEY") or "not-used"),
         base_url=os.getenv("LLM_BASE_URL"),
+        completion_semaphore=llm_semaphore,
     )
     condenser = LLMSummarizingCondenser(
         llm=condenser_llm,
@@ -423,6 +434,7 @@ async def process_row_async(
     include_trajectories: bool = True,
     max_size: int = DEFAULT_MAX_SIZE,
     keep_first: int = 2,
+    llm_semaphore: asyncio.Semaphore | None = None,
 ) -> list[dict[str, Any]]:
     trajectory = load_trajectory(line)
     output_trajectory_id = trajectory.id
@@ -457,6 +469,7 @@ async def process_row_async(
                 include_trajectories=include_trajectories,
                 output_trajectory_id=output_trajectory_id,
                 source_row_id=source_row_id,
+                llm_semaphore=llm_semaphore,
             )
         finally:
             conversation.close()
@@ -467,6 +480,7 @@ async def process_line(
     *,
     args: argparse.Namespace,
     semaphore: asyncio.Semaphore,
+    llm_semaphore: asyncio.Semaphore,
 ) -> list[dict[str, Any]]:
     try:
         async with semaphore:
@@ -477,6 +491,7 @@ async def process_line(
                 include_trajectories=args.include_trajectories == "yes",
                 max_size=args.max_size,
                 keep_first=args.keep_first,
+                llm_semaphore=llm_semaphore,
             )
             if args.row_timeout > 0:
                 return await asyncio.wait_for(row_task, timeout=args.row_timeout)
@@ -527,6 +542,7 @@ async def process_stream(args: argparse.Namespace) -> None:
     from tqdm import tqdm
 
     semaphore = asyncio.Semaphore(args.concurrency)
+    llm_semaphore = asyncio.Semaphore(args.llm_concurrency)
     max_in_flight = max(args.chunk_size, args.concurrency)
     progress = tqdm(
         desc="condensation_sft",
@@ -545,7 +561,14 @@ async def process_stream(args: argparse.Namespace) -> None:
                 line = line.strip()
                 if line:
                     pending.add(
-                        asyncio.create_task(process_line(line, args=args, semaphore=semaphore))
+                        asyncio.create_task(
+                            process_line(
+                                line,
+                                args=args,
+                                semaphore=semaphore,
+                                llm_semaphore=llm_semaphore,
+                            )
+                        )
                     )
                     break
             else:
@@ -600,6 +623,15 @@ def main() -> None:
         help="Maximum number of input rows to keep scheduled at once.",
     )
     parser.add_argument(
+        "--llm-concurrency",
+        type=int,
+        default=int(os.getenv("ADP_CONDENSER_LLM_CONCURRENCY", "0")),
+        help=(
+            "Maximum concurrent async condenser LLM requests. Defaults to "
+            "--concurrency when unset or 0."
+        ),
+    )
+    parser.add_argument(
         "--no-progress",
         action="store_true",
         help="Disable tqdm progress output on stderr.",
@@ -623,6 +655,10 @@ def main() -> None:
         raise ValueError("--concurrency must be at least 1")
     if args.chunk_size < 1:
         raise ValueError("--chunk-size must be at least 1")
+    if args.llm_concurrency < 0:
+        raise ValueError("--llm-concurrency must be non-negative")
+    if args.llm_concurrency == 0:
+        args.llm_concurrency = args.concurrency
     if args.row_timeout < 0:
         raise ValueError("--row-timeout must be non-negative")
     try:

--- a/agents/openhands_sdk/condensation_sft.py
+++ b/agents/openhands_sdk/condensation_sft.py
@@ -23,6 +23,8 @@ from openhands.sdk.event.condenser import Condensation
 from openhands.sdk.llm.llm_response import LLMResponse
 from openhands.sdk.tool import ToolDefinition
 from pydantic import PrivateAttr, SecretStr
+from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt
+from tenacity import wait_exponential_jitter
 
 from agents.openhands_sdk.std_to_sft import (
     SDKEventBuilder,
@@ -64,12 +66,30 @@ class PromptCapturingLLM(LLM):
 
     _captured_messages: list[list[Message]] = PrivateAttr(default_factory=list)
     _completion_semaphore: asyncio.Semaphore | None = PrivateAttr(default=None)
+    _llm_retries: int = PrivateAttr(default=1)
+    _llm_retry_min_wait: float = PrivateAttr(default=1.0)
+    _llm_retry_max_wait: float = PrivateAttr(default=30.0)
 
     def __init__(self, **data: Any) -> None:
         completion_semaphore = data.pop("completion_semaphore", None)
+        llm_retries = data.pop(
+            "llm_retries",
+            int(os.getenv("ADP_CONDENSER_LLM_RETRIES", "3")),
+        )
+        llm_retry_min_wait = data.pop(
+            "llm_retry_min_wait",
+            float(os.getenv("ADP_CONDENSER_LLM_RETRY_MIN_WAIT", "1")),
+        )
+        llm_retry_max_wait = data.pop(
+            "llm_retry_max_wait",
+            float(os.getenv("ADP_CONDENSER_LLM_RETRY_MAX_WAIT", "30")),
+        )
         super().__init__(**data)
         self._captured_messages = []
         self._completion_semaphore = completion_semaphore
+        self._llm_retries = max(1, llm_retries)
+        self._llm_retry_min_wait = max(0, llm_retry_min_wait)
+        self._llm_retry_max_wait = max(self._llm_retry_min_wait, llm_retry_max_wait)
 
     @property
     def captured_messages(self) -> list[list[Message]]:
@@ -84,8 +104,9 @@ class PromptCapturingLLM(LLM):
         on_token: Any | None = None,
         **kwargs: Any,
     ) -> LLMResponse:
+        self._captured_messages.append(messages)
+
         async def run_completion() -> LLMResponse:
-            self._captured_messages.append(messages)
             return await super(PromptCapturingLLM, self).acompletion(
                 messages=messages,
                 tools=tools,
@@ -95,10 +116,26 @@ class PromptCapturingLLM(LLM):
                 **kwargs,
             )
 
+        async def run_with_retries() -> LLMResponse:
+            if self._llm_retries <= 1:
+                return await run_completion()
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(self._llm_retries),
+                wait=wait_exponential_jitter(
+                    initial=self._llm_retry_min_wait,
+                    max=self._llm_retry_max_wait,
+                ),
+                retry=retry_if_exception_type(Exception),
+                reraise=True,
+            ):
+                with attempt:
+                    return await run_completion()
+            raise RuntimeError("unreachable retry state")
+
         if self._completion_semaphore is None:
-            return await run_completion()
+            return await run_with_retries()
         async with self._completion_semaphore:
-            return await run_completion()
+            return await run_with_retries()
 
 
 def format_messages(llm: LLM, messages: list[Message]) -> list[dict[str, Any]]:
@@ -481,8 +518,29 @@ async def process_line(
     args: argparse.Namespace,
     llm_semaphore: asyncio.Semaphore,
 ) -> list[dict[str, Any]]:
-    try:
-        row_task = process_row_async(
+    def row_id() -> Any:
+        try:
+            row = json.loads(line)
+        except Exception:
+            return None
+        return row.get("id") or row.get("trajectory_id") or row.get("session_id")
+
+    def log_error(error_type: str, error: str) -> None:
+        print(
+            json.dumps(
+                {
+                    "id": row_id(),
+                    "error_type": error_type,
+                    "error": error,
+                },
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
+
+    row_task = asyncio.create_task(
+        process_row_async(
             line,
             max_tokens=args.max_tokens,
             model=args.model,
@@ -491,48 +549,26 @@ async def process_line(
             keep_first=args.keep_first,
             llm_semaphore=llm_semaphore,
         )
+    )
+    try:
         if args.row_timeout > 0:
             return await asyncio.wait_for(row_task, timeout=args.row_timeout)
         return await row_task
+    except asyncio.CancelledError:
+        row_task.cancel()
+        await asyncio.gather(row_task, return_exceptions=True)
+        raise
     except asyncio.TimeoutError:
-        row_id = None
-        try:
-            row_id = json.loads(line).get("id")
-        except Exception:
-            pass
-        print(
-            json.dumps(
-                {
-                    "id": row_id,
-                    "error_type": "TimeoutError",
-                    "error": f"row exceeded timeout={args.row_timeout}s",
-                },
-                ensure_ascii=False,
-            ),
-            file=sys.stderr,
-            flush=True,
-        )
+        row_task.cancel()
+        await asyncio.gather(row_task, return_exceptions=True)
+        log_error("TimeoutError", f"row exceeded timeout={args.row_timeout}s")
+        if args.continue_on_error:
+            return []
         raise
     except Exception as exc:
         if not args.continue_on_error:
             raise
-        row_id = None
-        try:
-            row_id = json.loads(line).get("id")
-        except Exception:
-            pass
-        print(
-            json.dumps(
-                {
-                    "id": row_id,
-                    "error_type": type(exc).__name__,
-                    "error": str(exc),
-                },
-                ensure_ascii=False,
-            ),
-            file=sys.stderr,
-            flush=True,
-        )
+        log_error(type(exc).__name__, str(exc))
         return []
 
 
@@ -574,7 +610,24 @@ async def process_stream(args: argparse.Namespace) -> None:
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             for task in done:
-                records = await task
+                try:
+                    records = await task
+                except Exception as exc:
+                    if not args.continue_on_error:
+                        raise
+                    print(
+                        json.dumps(
+                            {
+                                "id": None,
+                                "error_type": type(exc).__name__,
+                                "error": str(exc),
+                            },
+                            ensure_ascii=False,
+                        ),
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    records = []
                 for record in records:
                     print(json.dumps(record, ensure_ascii=False), flush=True)
                 progress.update(1)
@@ -645,6 +698,24 @@ def main() -> None:
             "Set to 0 to disable."
         ),
     )
+    parser.add_argument(
+        "--llm-retries",
+        type=int,
+        default=int(os.getenv("ADP_CONDENSER_LLM_RETRIES", "3")),
+        help="Maximum attempts for each async condenser LLM request.",
+    )
+    parser.add_argument(
+        "--llm-retry-min-wait",
+        type=float,
+        default=float(os.getenv("ADP_CONDENSER_LLM_RETRY_MIN_WAIT", "1")),
+        help="Minimum retry wait in seconds for async condenser LLM requests.",
+    )
+    parser.add_argument(
+        "--llm-retry-max-wait",
+        type=float,
+        default=float(os.getenv("ADP_CONDENSER_LLM_RETRY_MAX_WAIT", "30")),
+        help="Maximum retry wait in seconds for async condenser LLM requests.",
+    )
     args = parser.parse_args()
     if args.chunk_size is not None:
         args.max_in_flight_rows = args.chunk_size
@@ -656,6 +727,15 @@ def main() -> None:
         args.llm_concurrency = args.max_in_flight_rows
     if args.row_timeout < 0:
         raise ValueError("--row-timeout must be non-negative")
+    if args.llm_retries < 1:
+        raise ValueError("--llm-retries must be at least 1")
+    if args.llm_retry_min_wait < 0:
+        raise ValueError("--llm-retry-min-wait must be non-negative")
+    if args.llm_retry_max_wait < args.llm_retry_min_wait:
+        raise ValueError("--llm-retry-max-wait must be at least --llm-retry-min-wait")
+    os.environ["ADP_CONDENSER_LLM_RETRIES"] = str(args.llm_retries)
+    os.environ["ADP_CONDENSER_LLM_RETRY_MIN_WAIT"] = str(args.llm_retry_min_wait)
+    os.environ["ADP_CONDENSER_LLM_RETRY_MAX_WAIT"] = str(args.llm_retry_max_wait)
     try:
         asyncio.run(process_stream(args))
     except asyncio.TimeoutError:

--- a/agents/openhands_sdk/std_to_sft.py
+++ b/agents/openhands_sdk/std_to_sft.py
@@ -302,6 +302,8 @@ def normalize_parameters(function: OpenAIToolSpec) -> dict[str, Any]:
 
 
 def make_metadata_tool(name: str, tool_spec: OpenAIToolSpec) -> type[ToolDefinition]:
+    # Preserve raw dataset arguments even when metadata schemas are incomplete.
+    # The emitted OpenAI tool call still records the original JSON arguments.
     parameters = {**normalize_parameters(tool_spec), "additionalProperties": True}
     action_type = SDKAction.from_mcp_schema(f"{class_name(name)}Action", parameters)
     description = tool_spec.function.description or f"Dataset metadata tool {name}."
@@ -443,6 +445,8 @@ def custom_tool_uses_browser_index(tool_spec: OpenAIToolSpec) -> bool:
 
 def sdk_tool_specs(trajectory: Trajectory, metadata: DatasetMetadata) -> list[Tool]:
     specs: list[Tool] = []
+    # ATIF CodeAction.language is structural converter output, not inferred from
+    # model usage, so use it to preserve code actions missing from old metadata.
     code_languages = {
         *{language.lower() for language in metadata.code_enabled},
         *trajectory_code_languages(trajectory),
@@ -734,7 +738,19 @@ def make_action_event(
     args = json_safe_args(args)
     try:
         action = sdk_tool.action_from_arguments(args)
-    except ValidationError:
+    except ValidationError as exc:
+        print(
+            json.dumps(
+                {
+                    "event": "dataset_tool_schema_fallback",
+                    "tool_name": tool_name,
+                    "error": str(exc),
+                },
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
         action = DatasetAnyAction.model_validate(args)
     tool_call = MessageToolCall(
         id=explicit_id or tool_call_id(call_index, tool_name),

--- a/agents/openhands_sdk/std_to_sft.py
+++ b/agents/openhands_sdk/std_to_sft.py
@@ -128,7 +128,7 @@ def parse_scalar(value: Any) -> Any:
         return value
     try:
         return ast.literal_eval(value)
-    except (ValueError, SyntaxError):
+    except (TypeError, ValueError, SyntaxError):
         return value
 
 

--- a/agents/openhands_sdk/std_to_sft.py
+++ b/agents/openhands_sdk/std_to_sft.py
@@ -475,10 +475,12 @@ def sdk_tool_specs(trajectory: Trajectory, metadata: DatasetMetadata) -> list[To
         if should_treat_as_browser_tool(source_name, metadata, registered_custom_tools):
             continue
         if mapped_name == "terminal":
-            specs.append(Tool(name=TerminalTool.name))
+            if not any(tool.name == TerminalTool.name for tool in specs):
+                specs.append(Tool(name=TerminalTool.name))
             continue
         if mapped_name == "file_editor":
-            specs.append(Tool(name=FileEditorTool.name))
+            if not any(tool.name == FileEditorTool.name for tool in specs):
+                specs.append(Tool(name=FileEditorTool.name))
             continue
         if mapped_name == "task_tracker":
             specs.append(Tool(name=TaskTrackerTool.name))

--- a/agents/openhands_sdk/std_to_sft.py
+++ b/agents/openhands_sdk/std_to_sft.py
@@ -393,6 +393,14 @@ def trajectory_api_functions(trajectory: Trajectory) -> list[str]:
     ]
 
 
+def trajectory_code_languages(trajectory: Trajectory) -> set[str]:
+    return {
+        event.language.lower()
+        for event in trajectory.content
+        if isinstance(event, CodeAction) and event.language
+    }
+
+
 def ordered_unique(values: Sequence[str]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
@@ -435,7 +443,10 @@ def custom_tool_uses_browser_index(tool_spec: OpenAIToolSpec) -> bool:
 
 def sdk_tool_specs(trajectory: Trajectory, metadata: DatasetMetadata) -> list[Tool]:
     specs: list[Tool] = []
-    code_languages = {language.lower() for language in metadata.code_enabled}
+    code_languages = {
+        *{language.lower() for language in metadata.code_enabled},
+        *trajectory_code_languages(trajectory),
+    }
     if code_languages & SUPPORTED_TERMINAL_CODE_LANGUAGES:
         specs.append(Tool(name=TerminalTool.name))
     if metadata.file_editor_enabled:
@@ -460,8 +471,7 @@ def sdk_tool_specs(trajectory: Trajectory, metadata: DatasetMetadata) -> list[To
         if should_treat_as_browser_tool(source_name, metadata, registered_custom_tools):
             continue
         if mapped_name == "terminal":
-            if "bash" not in metadata.code_enabled:
-                raise ValueError(f"{source_name!r} maps to terminal, but bash is disabled")
+            specs.append(Tool(name=TerminalTool.name))
             continue
         if mapped_name == "file_editor":
             specs.append(Tool(name=FileEditorTool.name))

--- a/agents/openhands_sdk/std_to_sft.py
+++ b/agents/openhands_sdk/std_to_sft.py
@@ -758,12 +758,12 @@ def make_action_event(
     call_index: int,
     llm_response_id: str,
 ) -> ActionEvent:
+    global DATASET_TOOL_SCHEMA_FALLBACK_COUNT
+
     args = json_safe_args(args)
     try:
         action = sdk_tool.action_from_arguments(args)
     except ValidationError as exc:
-        global DATASET_TOOL_SCHEMA_FALLBACK_COUNT
-
         DATASET_TOOL_SCHEMA_FALLBACK_COUNT += 1
         print(
             json.dumps(

--- a/agents/openhands_sdk/std_to_sft.py
+++ b/agents/openhands_sdk/std_to_sft.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import atexit
 import hashlib
 import json
 import os
@@ -60,6 +61,26 @@ except Exception:  # noqa: BLE001
     BrowserToolSet = None
 
 _REGISTERED_METADATA_TOOL_SPECS: dict[str, dict[str, Any]] = {}
+DATASET_TOOL_SCHEMA_FALLBACK_COUNT = 0
+
+
+def report_dataset_tool_schema_fallback_count() -> None:
+    if not DATASET_TOOL_SCHEMA_FALLBACK_COUNT:
+        return
+    print(
+        json.dumps(
+            {
+                "event": "dataset_tool_schema_fallback_summary",
+                "count": DATASET_TOOL_SCHEMA_FALLBACK_COUNT,
+            },
+            ensure_ascii=False,
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+atexit.register(report_dataset_tool_schema_fallback_count)
 
 BROWSER_TOOL_ALIASES = {
     "back": "browser_go_back",
@@ -741,6 +762,9 @@ def make_action_event(
     try:
         action = sdk_tool.action_from_arguments(args)
     except ValidationError as exc:
+        global DATASET_TOOL_SCHEMA_FALLBACK_COUNT
+
+        DATASET_TOOL_SCHEMA_FALLBACK_COUNT += 1
         print(
             json.dumps(
                 {

--- a/agents/openhands_sdk/std_to_sft.py
+++ b/agents/openhands_sdk/std_to_sft.py
@@ -34,7 +34,7 @@ from openhands.tools.file_editor import FileEditorTool
 from openhands.tools.task_tracker import TaskTrackerTool
 from openhands.tools.terminal import TerminalTool
 from openhands.tools.terminal.definition import MAX_CMD_OUTPUT_SIZE, maybe_truncate
-from pydantic import ConfigDict, SecretStr
+from pydantic import ConfigDict, SecretStr, ValidationError
 
 from schema.dataset_metadata import (
     DatasetMetadata,
@@ -302,7 +302,7 @@ def normalize_parameters(function: OpenAIToolSpec) -> dict[str, Any]:
 
 
 def make_metadata_tool(name: str, tool_spec: OpenAIToolSpec) -> type[ToolDefinition]:
-    parameters = normalize_parameters(tool_spec)
+    parameters = {**normalize_parameters(tool_spec), "additionalProperties": True}
     action_type = SDKAction.from_mcp_schema(f"{class_name(name)}Action", parameters)
     description = tool_spec.function.description or f"Dataset metadata tool {name}."
 
@@ -722,6 +722,10 @@ def make_action_event(
     llm_response_id: str,
 ) -> ActionEvent:
     args = json_safe_args(args)
+    try:
+        action = sdk_tool.action_from_arguments(args)
+    except ValidationError:
+        action = DatasetAnyAction.model_validate(args)
     tool_call = MessageToolCall(
         id=explicit_id or tool_call_id(call_index, tool_name),
         name=tool_name,
@@ -731,7 +735,7 @@ def make_action_event(
     return ActionEvent(
         thought=[TextContent(text=thought)] if thought else [],
         reasoning_content=reasoning_content,
-        action=sdk_tool.action_from_arguments(args),
+        action=action,
         tool_name=tool_name,
         tool_call_id=tool_call.id,
         tool_call=tool_call,

--- a/datasets/CharlieDreemur_OpenManus-RL/extract_raw.py
+++ b/datasets/CharlieDreemur_OpenManus-RL/extract_raw.py
@@ -1,9 +1,13 @@
 import json
 import os
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Iterable
+
+from tenacity import retry, retry_if_exception, stop_after_attempt
+from tenacity import wait_exponential_jitter
 
 DATASET_NAME = "CharlieDreemur/OpenManus-RL"
 CONFIG = "default"
@@ -17,6 +21,18 @@ PAGE_SIZE = 100
 REPRESENTATIVE_OFFSETS = [0, 5000, 10000, 20000, 48920]
 
 
+def is_retryable_fetch_error(exc: BaseException) -> bool:
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code in {429, 500, 502, 503, 504}
+    return isinstance(exc, (TimeoutError, urllib.error.URLError))
+
+
+@retry(
+    retry=retry_if_exception(is_retryable_fetch_error),
+    wait=wait_exponential_jitter(initial=1, max=60),
+    stop=stop_after_attempt(int(os.getenv("OPENMANUS_RL_FETCH_RETRIES", "8"))),
+    reraise=True,
+)
 def fetch_rows(offset: int, length: int) -> dict:
     params = urllib.parse.urlencode(
         {

--- a/datasets/CharlieDreemur_OpenManus-RL/extract_raw.py
+++ b/datasets/CharlieDreemur_OpenManus-RL/extract_raw.py
@@ -6,8 +6,7 @@ import urllib.parse
 import urllib.request
 from typing import Iterable
 
-from tenacity import retry, retry_if_exception, stop_after_attempt
-from tenacity import wait_exponential_jitter
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter
 
 DATASET_NAME = "CharlieDreemur/OpenManus-RL"
 CONFIG = "default"

--- a/datasets/android_in_the_wild/extract_raw.py
+++ b/datasets/android_in_the_wild/extract_raw.py
@@ -16,6 +16,8 @@ credential_path = os.path.join(
 )
 if os.path.exists(credential_path):
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = credential_path
+# Leave ADC unset when the file is absent so hosted runtimes can authenticate
+# through metadata-server credentials instead of failing before TensorFlow reads GCS.
 os.environ["CURL_CA_BUNDLE"] = certifi.where()
 
 # Define dataset directories

--- a/datasets/android_in_the_wild/extract_raw.py
+++ b/datasets/android_in_the_wild/extract_raw.py
@@ -21,7 +21,8 @@ if os.path.exists(credential_path):
 # through metadata-server credentials instead of failing before TensorFlow reads GCS.
 elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
     print(
-        "GOOGLE_APPLICATION_CREDENTIALS is not set; relying on ambient ADC credentials",
+        "GOOGLE_APPLICATION_CREDENTIALS is not set; relying on ambient ADC credentials. "
+        "If running locally, authenticate with: gcloud auth application-default login",
         file=sys.stderr,
     )
 os.environ["CURL_CA_BUNDLE"] = certifi.where()

--- a/datasets/android_in_the_wild/extract_raw.py
+++ b/datasets/android_in_the_wild/extract_raw.py
@@ -14,12 +14,8 @@ from PIL import Image, ImageDraw
 credential_path = os.path.join(
     os.environ["HOME"], ".config/gcloud/application_default_credentials.json"
 )
-if not os.path.exists(credential_path):
-    raise FileNotFoundError(
-        f"Credential file not found at {credential_path}\n Please run `gcloud auth application-default login` to set up your credentials."
-    )
-
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = credential_path
+if os.path.exists(credential_path):
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = credential_path
 os.environ["CURL_CA_BUNDLE"] = certifi.where()
 
 # Define dataset directories

--- a/datasets/android_in_the_wild/extract_raw.py
+++ b/datasets/android_in_the_wild/extract_raw.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 from typing import Any, Dict, List, Tuple
 
 import certifi
@@ -18,6 +19,11 @@ if os.path.exists(credential_path):
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = credential_path
 # Leave ADC unset when the file is absent so hosted runtimes can authenticate
 # through metadata-server credentials instead of failing before TensorFlow reads GCS.
+elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
+    print(
+        "GOOGLE_APPLICATION_CREDENTIALS is not set; relying on ambient ADC credentials",
+        file=sys.stderr,
+    )
 os.environ["CURL_CA_BUNDLE"] = certifi.where()
 
 # Define dataset directories

--- a/datasets/go-browse-wa/raw_to_atif.py
+++ b/datasets/go-browse-wa/raw_to_atif.py
@@ -62,8 +62,15 @@ def get_action_string(raw_step: dict[str, Any]) -> str:
             action_data = json.loads(raw_action)
         except json.JSONDecodeError:
             action_data = None
-        if isinstance(action_data, dict) and isinstance(action_data.get("action"), str):
-            return action_data["action"]
+        if isinstance(action_data, dict):
+            action_value = action_data.get("action")
+            if isinstance(action_value, str):
+                return action_value
+            if isinstance(action_value, dict) and len(action_value) == 1:
+                function_name, arguments = next(iter(action_value.items()))
+                if isinstance(arguments, dict):
+                    kwargs = ", ".join(f"{key}={value!r}" for key, value in arguments.items())
+                    return f"{function_name}({kwargs})"
 
         match = re.search(r'"action"\s*:\s*("(?:\\.|[^"\\])*")', raw_action)
         if match:

--- a/datasets/go-browse-wa/raw_to_atif.py
+++ b/datasets/go-browse-wa/raw_to_atif.py
@@ -217,6 +217,8 @@ def emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) ->
 
 
 def safe_emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) -> None:
+    # Some source trajectories contain malformed or consecutive noop actions.
+    # Skip only those trajectories instead of rejecting the whole conversion run.
     try:
         emit_trajectory(traj_id, goal, raw_steps)
     except Exception as exc:

--- a/datasets/go-browse-wa/raw_to_atif.py
+++ b/datasets/go-browse-wa/raw_to_atif.py
@@ -133,7 +133,11 @@ def get_action_string(raw_step: dict[str, Any]) -> str:
                 action_value = action_value[:-1].strip()
             if action_value.endswith('"'):
                 action_value = action_value[:-1].strip()
-            return action_value
+            try:
+                parse_action(action_value)
+                return action_value
+            except (SyntaxError, ValueError):
+                pass
 
     raise ValueError(
         "missing parsed action for "

--- a/datasets/go-browse-wa/raw_to_atif.py
+++ b/datasets/go-browse-wa/raw_to_atif.py
@@ -217,8 +217,8 @@ def emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) ->
 
 
 def safe_emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) -> None:
-    # Some source trajectories contain malformed or consecutive noop actions.
-    # Skip only those trajectories instead of rejecting the whole conversion run.
+    # Consecutive noop actions are valid wait events in this source data; only
+    # skip trajectories that are malformed or incomplete.
     try:
         emit_trajectory(traj_id, goal, raw_steps)
     except Exception as exc:

--- a/datasets/go-browse-wa/raw_to_atif.py
+++ b/datasets/go-browse-wa/raw_to_atif.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import json
+import re
 import sys
 from typing import Any
 
@@ -49,6 +50,32 @@ def parse_action(action_str: str) -> tuple[str, dict[str, Any]]:
     return function_name, kwargs
 
 
+def get_action_string(raw_step: dict[str, Any]) -> str:
+    step_data = raw_step["step_data"]
+    parsed_action = step_data.get("parsed_action")
+    if isinstance(parsed_action, str) and parsed_action.strip():
+        return parsed_action
+
+    raw_action = step_data.get("action")
+    if isinstance(raw_action, str):
+        try:
+            action_data = json.loads(raw_action)
+        except json.JSONDecodeError:
+            action_data = None
+        if isinstance(action_data, dict) and isinstance(action_data.get("action"), str):
+            return action_data["action"]
+
+        match = re.search(r'"action"\s*:\s*("(?:\\.|[^"\\])*")', raw_action)
+        if match:
+            return json.loads(match.group(1))
+
+    raise ValueError(
+        "missing parsed action for "
+        f"trajectory {raw_step.get('traj_data', {}).get('traj_num')} "
+        f"step {step_data.get('step_number')}"
+    )
+
+
 def make_observation_step(step_id: int, raw_step: dict[str, Any]) -> Step:
     step_data = raw_step["step_data"]
     return Step(
@@ -82,7 +109,7 @@ def make_observation_step(step_id: int, raw_step: dict[str, Any]) -> Step:
 
 
 def make_action_step(step_id: int, raw_step: dict[str, Any], call_id: str) -> Step:
-    function_name, kwargs = parse_action(raw_step["step_data"]["parsed_action"])
+    function_name, kwargs = parse_action(get_action_string(raw_step))
     thought = raw_step["step_data"].get("thought")
     if function_name == "send_msg_to_user":
         function_name = "finish"
@@ -106,7 +133,7 @@ def emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) ->
     next_step_id = 2
     next_call_id = 1
     for raw_step in raw_steps:
-        function_name, _ = parse_action(raw_step["step_data"]["parsed_action"])
+        function_name, _ = parse_action(get_action_string(raw_step))
         steps.append(make_observation_step(next_step_id, raw_step))
         next_step_id += 1
         steps.append(make_action_step(next_step_id, raw_step, f"call_{next_call_id:06d}"))

--- a/datasets/go-browse-wa/raw_to_atif.py
+++ b/datasets/go-browse-wa/raw_to_atif.py
@@ -105,12 +105,8 @@ def emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) ->
     steps = [Step(step_id=1, source="user", message=goal)]
     next_step_id = 2
     next_call_id = 1
-    previous_action = ""
     for raw_step in raw_steps:
         function_name, _ = parse_action(raw_step["step_data"]["parsed_action"])
-        if previous_action == "noop" and function_name == "noop":
-            raise ValueError("consecutive noop")
-        previous_action = function_name
         steps.append(make_observation_step(next_step_id, raw_step))
         next_step_id += 1
         steps.append(make_action_step(next_step_id, raw_step, f"call_{next_call_id:06d}"))

--- a/datasets/go-browse-wa/raw_to_atif.py
+++ b/datasets/go-browse-wa/raw_to_atif.py
@@ -11,6 +11,14 @@ from typing import Any
 from schema.atif import Agent, ATIFObservation, ATIFTrajectory, ObservationResult, Step, ToolCall
 
 GO_BROWSE_WA_VIEWPORT_SIZE = (1280, 1440)
+POSITIONAL_ACTION_ARGS = {
+    "click": ["bid"],
+    "fill": ["bid", "value"],
+    "select_option": ["bid", "options"],
+    "scroll": ["delta_x", "delta_y"],
+    "send_msg_to_user": ["text"],
+    "noop": ["wait_ms"],
+}
 
 
 def ast_value(node: ast.AST) -> Any:
@@ -24,7 +32,13 @@ def ast_value(node: ast.AST) -> Any:
 
 
 def parse_action(action_str: str) -> tuple[str, dict[str, Any]]:
-    tree = ast.parse(action_str)
+    try:
+        tree = ast.parse(action_str)
+    except SyntaxError:
+        recovered = parse_malformed_action(action_str)
+        if recovered is not None:
+            return recovered
+        raise
     if not isinstance(tree.body[0], ast.Expr) or not isinstance(tree.body[0].value, ast.Call):
         raise ValueError(f"Invalid action string: {action_str}")
     call = tree.body[0].value
@@ -32,14 +46,7 @@ def parse_action(action_str: str) -> tuple[str, dict[str, Any]]:
         raise ValueError(f"Invalid action function: {action_str}")
     function_name = call.func.id
     kwargs: dict[str, Any] = {}
-    positional_names = {
-        "click": ["bid"],
-        "fill": ["bid", "value"],
-        "select_option": ["bid", "options"],
-        "scroll": ["delta_x", "delta_y"],
-        "send_msg_to_user": ["text"],
-        "noop": ["wait_ms"],
-    }.get(function_name, [])
+    positional_names = POSITIONAL_ACTION_ARGS.get(function_name, [])
     for index, arg in enumerate(call.args):
         key = positional_names[index] if index < len(positional_names) else f"arg{index}"
         kwargs[key] = ast_value(arg)
@@ -50,11 +57,49 @@ def parse_action(action_str: str) -> tuple[str, dict[str, Any]]:
     return function_name, kwargs
 
 
+def parse_malformed_action(action_str: str) -> tuple[str, dict[str, Any]] | None:
+    match = re.match(r"^([A-Za-z_]\w*)\((.*)\)\}?$", action_str.strip(), flags=re.DOTALL)
+    if not match:
+        return None
+    function_name = match.group(1)
+    positional_names = POSITIONAL_ACTION_ARGS.get(function_name)
+    if not positional_names:
+        return None
+    args_text = match.group(2)
+    if function_name == "send_msg_to_user":
+        raw_args = [args_text.strip()] if args_text else []
+    elif function_name in {"click", "noop"}:
+        raw_args = [args_text.split(",", 1)[0].strip()] if args_text else []
+    else:
+        max_splits = max(len(positional_names) - 1, 0)
+        raw_args = [part.strip() for part in args_text.split(",", max_splits)] if args_text else []
+    kwargs = {}
+    for index, raw_arg in enumerate(raw_args[: len(positional_names)]):
+        kwargs[positional_names[index]] = parse_malformed_arg(raw_arg)
+    return function_name, kwargs
+
+
+def parse_malformed_arg(raw_arg: str) -> Any:
+    try:
+        return ast.literal_eval(raw_arg)
+    except (SyntaxError, ValueError):
+        value = raw_arg.strip()
+        if value[:1] in {"'", '"'}:
+            value = value[1:]
+        if value[-1:] in {"'", '"'}:
+            value = value[:-1]
+        return value
+
+
 def get_action_string(raw_step: dict[str, Any]) -> str:
     step_data = raw_step["step_data"]
     parsed_action = step_data.get("parsed_action")
     if isinstance(parsed_action, str) and parsed_action.strip():
-        return parsed_action
+        try:
+            parse_action(parsed_action)
+            return parsed_action
+        except (SyntaxError, ValueError):
+            pass
 
     raw_action = step_data.get("action")
     if isinstance(raw_action, str):
@@ -74,7 +119,21 @@ def get_action_string(raw_step: dict[str, Any]) -> str:
 
         match = re.search(r'"action"\s*:\s*("(?:\\.|[^"\\])*")', raw_action)
         if match:
-            return json.loads(match.group(1))
+            action_value = json.loads(match.group(1))
+            try:
+                parse_action(action_value)
+                return action_value
+            except (SyntaxError, ValueError):
+                pass
+        marker = '"action": "'
+        marker_index = raw_action.rfind(marker)
+        if marker_index >= 0:
+            action_value = raw_action[marker_index + len(marker) :].strip()
+            if action_value.endswith("}"):
+                action_value = action_value[:-1].strip()
+            if action_value.endswith('"'):
+                action_value = action_value[:-1].strip()
+            return action_value
 
     raise ValueError(
         "missing parsed action for "
@@ -157,6 +216,13 @@ def emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) ->
     print(trajectory.model_dump_json(exclude_none=True))
 
 
+def safe_emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) -> None:
+    try:
+        emit_trajectory(traj_id, goal, raw_steps)
+    except Exception as exc:
+        print(f"Skipping trajectory {traj_id}: {exc}", file=sys.stderr)
+
+
 def main() -> None:
     current_traj_id: int | None = None
     current_goal = ""
@@ -169,14 +235,14 @@ def main() -> None:
         traj_data = raw_step["traj_data"]
         traj_id = int(traj_data["traj_num"])
         if current_traj_id is not None and traj_id != current_traj_id and current_steps:
-            emit_trajectory(current_traj_id, current_goal, current_steps)
+            safe_emit_trajectory(current_traj_id, current_goal, current_steps)
             current_steps = []
         current_traj_id = traj_id
         current_goal = traj_data["goal"]
         if traj_data.get("reward", 0) >= 1:
             current_steps.append(raw_step)
     if current_traj_id is not None and current_steps:
-        emit_trajectory(current_traj_id, current_goal, current_steps)
+        safe_emit_trajectory(current_traj_id, current_goal, current_steps)
 
 
 if __name__ == "__main__":

--- a/datasets/go-browse-wa/raw_to_atif.py
+++ b/datasets/go-browse-wa/raw_to_atif.py
@@ -199,7 +199,6 @@ def emit_trajectory(traj_id: int, goal: str, raw_steps: list[dict[str, Any]]) ->
     next_step_id = 2
     next_call_id = 1
     for raw_step in raw_steps:
-        function_name, _ = parse_action(get_action_string(raw_step))
         steps.append(make_observation_step(next_step_id, raw_step))
         next_step_id += 1
         steps.append(make_action_step(next_step_id, raw_step, f"call_{next_call_id:06d}"))

--- a/datasets/mind2web/extract_raw.py
+++ b/datasets/mind2web/extract_raw.py
@@ -1,66 +1,6 @@
 import json
-import os
-import time
-
-import globus_sdk
-import tqdm
-from globus_sdk.scopes import TransferScopes
 
 from datasets import load_dataset
-
-# Initialize auth_client globally
-auth_client = globus_sdk.NativeAppAuthClient("7414f0b4-7d05-4bb6-bb00-076fa3f17cf5")
-
-
-def do_submit(client, task_data):
-    task_doc = client.submit_transfer(task_data)
-    task_id = task_doc["task_id"]
-    return task_id
-
-
-def list_files(client, endpoint_id, path):
-    files = []
-    dirs_to_process = [path]
-
-    while dirs_to_process:
-        # if len(files) > 10:
-        #     return files
-        current_dir = dirs_to_process.pop()
-        response = client.operation_ls(endpoint_id, path=current_dir)
-
-        for entry in response:
-            if entry["type"] == "dir":
-                dirs_to_process.append(os.path.join(current_dir, entry["name"]))
-            elif entry["type"] == "file":
-                if entry["name"].endswith(".zip"):
-                    files.append(os.path.join(current_dir, entry["name"]))
-
-    return files
-
-
-def login_and_get_transfer_client(*, scopes=TransferScopes.all):
-    auth_client.oauth2_start_flow(requested_scopes=scopes)
-    authorize_url = auth_client.oauth2_get_authorize_url()
-    print(f"Please go to this URL and login:\n\n{authorize_url}\n")
-    auth_code = input("Please enter the code here: ").strip()
-    tokens = auth_client.oauth2_exchange_code_for_tokens(auth_code)
-    transfer_tokens = tokens.by_resource_server["transfer.api.globus.org"]
-
-    return globus_sdk.TransferClient(
-        authorizer=globus_sdk.AccessTokenAuthorizer(transfer_tokens["access_token"])
-    )
-
-
-def monitor_transfer(client, task_id):
-    with tqdm.tqdm(total=100, desc="Transfer Progress", unit="%") as pbar:
-        while True:
-            task = client.get_task(task_id)
-            completion = task["subtasks_succeeded"] / task["subtasks_total"] * 100
-            pbar.n = completion
-            pbar.refresh()
-            if task["subtasks_succeeded"] == task["subtasks_total"]:
-                break
-            time.sleep(5)  # wait for 5 seconds before checking again
 
 
 dataset = load_dataset("osunlp/Mind2Web", split="train")

--- a/datasets/mind2web/extract_raw.py
+++ b/datasets/mind2web/extract_raw.py
@@ -2,7 +2,6 @@ import json
 
 from datasets import load_dataset
 
-
 dataset = load_dataset("osunlp/Mind2Web", split="train")
 
 for sample in dataset:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
@@ -24,7 +24,7 @@ indent-style = "space"
 line-ending = "auto"
 
 [tool.mypy]
-python_version = "3.10"  # Updated to support pattern matching
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ openhands-sdk
 openhands-tools
 transformers
 jinja2
+tenacity

--- a/scripts/raw_to_atif_common.py
+++ b/scripts/raw_to_atif_common.py
@@ -195,13 +195,31 @@ def atif_content(content: Any) -> str | list[ContentPart]:
     return text_from_content(content)
 
 
+def json_safe_value(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(key): json_safe_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_safe_value(item) for item in value]
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return repr(value)
+
+
+def json_safe_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
+    return {str(key): json_safe_value(value) for key, value in arguments.items()}
+
+
 def parse_arguments(value: Any) -> dict[str, Any]:
     value = maybe_json(value)
     if isinstance(value, dict):
-        return value
+        return json_safe_arguments(value)
     if value in (None, ""):
         return {}
-    return {"value": value}
+    return {"value": json_safe_value(value)}
 
 
 def openai_tool_calls(message: dict[str, Any]) -> list[ToolCall]:
@@ -300,6 +318,7 @@ def function_calls_field_tool_calls(message: dict[str, Any]) -> list[ToolCall]:
                 }
             except (AttributeError, SyntaxError, ValueError):
                 arguments = {"arguments": match.group(2)}
+            arguments = json_safe_arguments(arguments)
         if not name:
             continue
         tool_calls.append(

--- a/scripts/raw_to_atif_common.py
+++ b/scripts/raw_to_atif_common.py
@@ -770,7 +770,7 @@ def screenagent_trajectories(items: list[Any], dataset_name: str) -> Iterable[AT
         )
 
 
-def trajectories_from_input(records: list[Any], dataset_name: str) -> Iterable[ATIFTrajectory]:
+def trajectories_from_input(records: Iterable[Any], dataset_name: str) -> Iterable[ATIFTrajectory]:
     for index, record in enumerate(records):
         if isinstance(record, list):
             yield from screenagent_trajectories(record, dataset_name)
@@ -787,7 +787,7 @@ def trajectories_from_input(records: list[Any], dataset_name: str) -> Iterable[A
 
 def main(script_file: str) -> None:
     dataset_name = dataset_name_from_script(script_file)
-    records = [json.loads(line) for line in sys.stdin if line.strip()]
+    records = (json.loads(line) for line in sys.stdin if line.strip())
     for trajectory in trajectories_from_input(records, dataset_name):
         print(trajectory.model_dump_json(exclude_none=True))
 

--- a/scripts/raw_to_atif_common.py
+++ b/scripts/raw_to_atif_common.py
@@ -291,12 +291,14 @@ def function_calls_field_tool_calls(message: dict[str, Any]) -> list[ToolCall]:
             name = match.group(1)
             try:
                 parsed = ast.parse(f"f({match.group(2)})", mode="eval")
+                if not isinstance(parsed.body, ast.Call):
+                    raise ValueError("function call arguments did not parse as a call")
                 arguments = {
                     keyword.arg: ast.literal_eval(keyword.value)
                     for keyword in parsed.body.keywords
                     if keyword.arg is not None
                 }
-            except (SyntaxError, ValueError):
+            except (AttributeError, SyntaxError, ValueError):
                 arguments = {"arguments": match.group(2)}
         if not name:
             continue

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,6 @@ from setuptools import find_namespace_packages, setup
 setup(
     name="agent-data-protocol",
     version="0.0.0",
+    python_requires=">=3.12",
     packages=find_namespace_packages(include=["agents*", "schema*", "scripts*"]),
 )


### PR DESCRIPTION
Adds a configurable per-row timeout to the async condenser SFT generation path so a wedged LiteLLM request fails the run and lets Slurm resume from the partial output instead of sitting idle until walltime.

Default: ADP_CONDENSER_ROW_TIMEOUT=1800 seconds; set 0 to disable.

Also updates the repo metadata to require Python >=3.12, matching the runtime used for the data-generation jobs and CI.

Go-browse consecutive noop actions are preserved as valid wait events; malformed or incomplete trajectories are skipped per trajectory rather than aborting the whole conversion run.

Validation: pre-commit run --all-files; pytest tests/test_*.py -q

Closes #266

## Issue

Closes #269
