### PR TITLE
Format sample fixture checker warning

### DIFF
--- a/scripts/check_sample_fixtures.py
+++ b/scripts/check_sample_fixtures.py
@@ -70,9 +70,7 @@ def check_dataset(dataset_dir: Path, update: bool) -> tuple[bool, str]:
         sample_std.write_text(regenerated)
         sft_dir = dataset_dir / "sample_sft"
         sft_warning = (
-            " (re-run agents/*/std_to_sft.py to refresh sample_sft/)"
-            if sft_dir.is_dir()
-            else ""
+            " (re-run agents/*/std_to_sft.py to refresh sample_sft/)" if sft_dir.is_dir() else ""
         )
         return True, f"updated {dataset_dir.name}{sft_warning}"
 


### PR DESCRIPTION
## Summary
- apply the ruff-format rewrite for the sample fixture checker warning expression

## Validation
- python scripts/check_sample_fixtures.py --dataset openthoughts_agent_sft
- python -m py_compile scripts/check_sample_fixtures.py
- uv run --no-project --python /usr/bin/python3.12 --with-requirements requirements.txt pre-commit run ruff-format --files scripts/check_sample_fixtures.py